### PR TITLE
fix(openebs): correct basePath to match Talos UserVolumeConfig mount point

### DIFF
--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
       localpv:
         image:
           registry: quay.io/
-        basePath: &basePath /var/openebs/local
+        basePath: &basePath /var/local-storage
       hostpathClass:
         enabled: true
         name: openebs-hostpath


### PR DESCRIPTION
## Summary
Fixes OpenEBS hostpath storage by correcting the basePath configuration to match where Talos actually mounts the UserVolumeConfig.

## Problem
- PostgreSQL PVC failing with `path "/var/openebs/local/pvc-xxx" does not exist`
- OpenEBS configured with `basePath: /var/openebs/local`
- But Talos UserVolumeConfig named `local-storage` creates mount at `/var/local-storage`

## Solution
- Change OpenEBS basePath from `/var/openebs/local` to `/var/local-storage`
- This matches all nodes since they all use UserVolumeConfig name `local-storage`

## Test plan
- [ ] OpenEBS storage class recreated with correct basePath
- [ ] PostgreSQL PVC can mount and provision
- [ ] PostgreSQL cluster becomes healthy
- [ ] Media services dependent on PostgreSQL can start

🤖 Generated with [Claude Code](https://claude.ai/code)