### PR TITLE
feat(ceph): expand device filter to include both Micron and XPG NVMe drives

### DIFF
--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -36,6 +36,8 @@ spec:
         image:
           registry: quay.io/
         basePath: &basePath /var/mnt/local-storage
+        analytics:
+          enabled: false
       hostpathClass:
         enabled: true
         name: openebs-hostpath

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
       storage:
         useAllNodes: true
         useAllDevices: false
-        devicePathFilter: /dev/disk/by-id/nvme-Micron_7300*
+        devicePathFilter: /dev/disk/by-id/nvme-(Micron_7300*|XPG_GAMMIX_S7*)
     cephBlockPools:
       - name: ceph-blockpool
         spec:


### PR DESCRIPTION
## Summary
- Update Ceph devicePathFilter to match both Micron_7300* and XPG_GAMMIX_S7* drives
- Fixes HEALTH_WARN state caused by undersized PGs due to missing OSDs on nodes with different NVMe drive types

## Background
The Ceph cluster was in HEALTH_WARN state with 33 PGs undersized/degraded because:
- Current filter `/dev/disk/by-id/nvme-XPG_GAMMIX_S7*` only matched drives on home04 
- home02 has Micron_7300 drives that weren't included
- home01 has no NVMe drives suitable for Ceph storage

## Changes
- Updated `devicePathFilter` from `nvme-Micron_7300*` to `nvme-(Micron_7300*|XPG_GAMMIX_S7*)`
- This allows Rook to discover and use NVMe drives on both home02 and home04
- Should resolve PG undersized/degraded issues by enabling proper 3-way replication

## Test Plan
- [ ] Deploy changes and verify Ceph discovers additional OSDs on home02
- [ ] Monitor cluster health transition from HEALTH_WARN to HEALTH_OK
- [ ] Verify PGs are no longer undersized/degraded after rebalancing

🤖 Generated with [Claude Code](https://claude.ai/code)