### PR TITLE
feat(talos): add NVMe UserVolumeConfig for Ceph storage

### DIFF
--- a/talos/static-configs/home01.yaml
+++ b/talos/static-configs/home01.yaml
@@ -228,6 +228,14 @@ provisioning:
     minSize: 25GiB
 ---
 apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: ceph-storage
+provisioning:
+    diskSelector:
+        match: disk.transport == "nvme" && !disk.system_disk
+    minSize: 100GiB
+---
+apiVersion: v1alpha1
 kind: EthernetConfig
 name: enp1s0
 rings:

--- a/talos/static-configs/home02.yaml
+++ b/talos/static-configs/home02.yaml
@@ -228,6 +228,14 @@ provisioning:
     minSize: 25GiB
 ---
 apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: ceph-storage
+provisioning:
+    diskSelector:
+        match: disk.transport == "nvme" && !disk.system_disk
+    minSize: 100GiB
+---
+apiVersion: v1alpha1
 kind: EthernetConfig
 name: enp1s0
 rings:

--- a/talos/static-configs/home03.yaml
+++ b/talos/static-configs/home03.yaml
@@ -224,6 +224,14 @@ provisioning:
     minSize: 25GiB
 ---
 apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: ceph-storage
+provisioning:
+    diskSelector:
+        match: disk.transport == "nvme" && !disk.system_disk
+    minSize: 100GiB
+---
+apiVersion: v1alpha1
 kind: EthernetConfig
 name: eno1
 rings:


### PR DESCRIPTION
## Summary
- Add separate `ceph-storage` UserVolumeConfig to expose NVMe drives on home01, home02, and home03
- Targets `disk.transport == "nvme" && \!disk.system_disk` with 100GiB minimum size
- Keeps existing `local-storage` config for SATA drives unchanged

## Background
Ceph cluster was in HEALTH_WARN with undersized PGs because:
- Talos UserVolumeConfig only exposed SATA drives (`disk.transport == "sata"`)
- NVMe drives existed on nodes but weren't mounted/accessible to Kubernetes
- Rook couldn't discover NVMe drives for Ceph storage

## Changes
- **home01**: Added ceph-storage UserVolumeConfig for NVMe drives
- **home02**: Added ceph-storage UserVolumeConfig for NVMe drives  
- **home03**: Added ceph-storage UserVolumeConfig for future use when node returns
- **home04**: Left unchanged (already has working NVMe access)

## Expected Result
- Talos will mount NVMe drives at `/var/mnt/ceph-storage` on affected nodes
- Rook will discover additional NVMe drives matching device filter `nvme-(Micron_7300*|XPG_GAMMIX_S7*)`
- Additional OSDs will be created on home01 and home02
- PGs will rebalance from 2 to 3 replicas, resolving HEALTH_WARN state

## Test Plan
- [ ] Apply updated Talos configs to home01 and home02
- [ ] Verify NVMe drives are mounted and accessible
- [ ] Monitor Rook for new OSD discovery and creation
- [ ] Verify Ceph cluster health transitions to HEALTH_OK

🤖 Generated with [Claude Code](https://claude.ai/code)