### PR TITLE
fix(talos): remove ceph-storage UserVolumeConfig to allow Rook direct device access

### DIFF
--- a/talos/static-configs/home01.yaml
+++ b/talos/static-configs/home01.yaml
@@ -228,14 +228,6 @@ provisioning:
     minSize: 25GiB
 ---
 apiVersion: v1alpha1
-kind: UserVolumeConfig
-name: ceph-storage
-provisioning:
-    diskSelector:
-        match: disk.transport == "nvme" && !disk.system_disk
-    minSize: 100GiB
----
-apiVersion: v1alpha1
 kind: EthernetConfig
 name: enp1s0
 rings:

--- a/talos/static-configs/home02.yaml
+++ b/talos/static-configs/home02.yaml
@@ -228,14 +228,6 @@ provisioning:
     minSize: 25GiB
 ---
 apiVersion: v1alpha1
-kind: UserVolumeConfig
-name: ceph-storage
-provisioning:
-    diskSelector:
-        match: disk.transport == "nvme" && !disk.system_disk
-    minSize: 100GiB
----
-apiVersion: v1alpha1
 kind: EthernetConfig
 name: enp1s0
 rings:

--- a/talos/static-configs/home03.yaml
+++ b/talos/static-configs/home03.yaml
@@ -224,14 +224,6 @@ provisioning:
     minSize: 25GiB
 ---
 apiVersion: v1alpha1
-kind: UserVolumeConfig
-name: ceph-storage
-provisioning:
-    diskSelector:
-        match: disk.transport == "nvme" && !disk.system_disk
-    minSize: 100GiB
----
-apiVersion: v1alpha1
 kind: EthernetConfig
 name: eno1
 rings:


### PR DESCRIPTION
## Summary
- Remove ceph-storage UserVolumeConfig from all Talos node configurations
- Allow Rook Ceph operator to manage NVMe drives directly using devicePathFilter
- Fix issue where Talos partitions prevented Rook from discovering available drives

## Background
The ceph-storage UserVolumeConfig was creating partitions on NVMe drives, which prevented Rook from using them as raw devices. Rook's device filter looks for whole devices, not partitions created by Talos UserVolumeConfig.

On home04, XPG drives work because they're used as raw devices. On home01/home02, Micron drives were being partitioned by UserVolumeConfig, making them unavailable to Rook.

## Test plan
- [x] Apply configs to home01 and home02 
- [x] Verify ceph-storage partitions are removed
- [x] Monitor Rook operator for new OSD discovery
- [x] Confirm new OSDs come online and cluster health improves

🤖 Generated with [Claude Code](https://claude.ai/code)