### PR TITLE
fix(volsync): add missing copyMethod to ReplicationSource template

### DIFF
--- a/kubernetes/components/volsync/seaweedfs/replicationsource.yaml
+++ b/kubernetes/components/volsync/seaweedfs/replicationsource.yaml
@@ -8,6 +8,7 @@ spec:
   trigger:
     schedule: "${VOLSYNC_SCHEDULE:-0 0 * * *}"
   restic:
+    copyMethod: "${VOLSYNC_COPYMETHOD:-Snapshot}"
     pruneIntervalDays: 7
     repository: "${APP}-restic-secret"
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-csi-ceph-blockpool}"


### PR DESCRIPTION
## Summary
- Add missing `copyMethod` field to VolSync ReplicationSource template
- Fixes media app PVCs stuck in pending state due to VolSync configuration error
- Resolves VolSync error: "unsupported copyMethod: -- must be Direct, None, Clone, or Snapshot"

## Root Cause
VolSync ReplicationSource objects were failing with configuration error because the `copyMethod` field was missing from the template. This prevented VolSync from creating ReplicationDestination objects, causing PVCs to remain pending.

## Test plan
- [x] Verify VolSync error logs identify missing copyMethod
- [ ] Merge PR and verify Flux reconciliation applies fix
- [ ] Confirm ReplicationSource objects get copyMethod field
- [ ] Verify media app PVCs can provision normally
- [ ] Test VolSync backup/restore cycle works

🤖 Generated with [Claude Code](https://claude.ai/code)