### PR TITLE
fix(volsync): correct VolumeSnapshotClass name to csi-ceph-block

### DIFF
--- a/kubernetes/components/volsync/seaweedfs/replicationsource.yaml
+++ b/kubernetes/components/volsync/seaweedfs/replicationsource.yaml
@@ -11,7 +11,7 @@ spec:
     copyMethod: "${VOLSYNC_COPYMETHOD:-Snapshot}"
     pruneIntervalDays: 7
     repository: "${APP}-restic-secret"
-    volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-csi-ceph-blockpool}"
+    volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-csi-ceph-block}"
     storageClassName: "${VOLSYNC_STORAGECLASS:-ceph-block}"
     moverSecurityContext:
       runAsUser: "${VOLSYNC_UID:-568}"


### PR DESCRIPTION
## Summary
- Correct VolumeSnapshotClass name from `csi-ceph-blockpool` to `csi-ceph-block`
- Fixes VolumeSnapshot binding failures preventing VolSync backups from working
- Follows up on PR #28 to complete VolSync configuration fixes

## Root Cause
VolSync ReplicationSource template was configured with incorrect VolumeSnapshotClass name `csi-ceph-blockpool`, but the actual class created by Rook Ceph is `csi-ceph-block`.

## Test plan
- [x] Verify `csi-ceph-block` VolumeSnapshotClass exists in cluster
- [ ] Merge PR and verify Flux reconciliation applies fix
- [ ] Confirm VolumeSnapshots can bind successfully
- [ ] Verify media app PVCs provision and pods start

🤖 Generated with [Claude Code](https://claude.ai/code)