### PR TITLE
Feat/ceph-nvme-matcher

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
       storage:
         useAllNodes: true
         useAllDevices: false
-        devicePathFilter: /dev/disk/by-id/nvme-(Micron_7300*|XPG_GAMMIX_S7*)
+        devicePathFilter: /dev/disk/by-id/nvme-*
     cephBlockPools:
       - name: ceph-blockpool
         spec:

--- a/talos/static-configs/home01.yaml
+++ b/talos/static-configs/home01.yaml
@@ -77,7 +77,7 @@ machine:
       - interface: bond0
         bond:
           deviceSelectors:
-            - {hardwareAddr: "7c:83:34:*", driver: igc}
+            - { hardwareAddr: "7c:83:34:*", driver: igc }
           mode: 802.3ad
           xmitHashPolicy: layer3+4
           lacpRate: fast
@@ -92,11 +92,11 @@ machine:
           # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
           - network: "10.0.48.83/32"
             gateway: "0.0.0.0"
-          - network: "10.0.48.84/30"  # 84-87
+          - network: "10.0.48.84/30" # 84-87
             gateway: "0.0.0.0"
-          - network: "10.0.48.88/29"  # 88-95
+          - network: "10.0.48.88/29" # 88-95
             gateway: "0.0.0.0"
-          - network: "10.0.48.96/27"  # 96-127
+          - network: "10.0.48.96/27" # 96-127
             gateway: "0.0.0.0"
           - network: "10.0.48.128/26" # 128-191
             gateway: "0.0.0.0"
@@ -106,7 +106,7 @@ machine:
             gateway: "0.0.0.0"
         mtu: 1500
         vlans:
-          - {vlanId: 30, dhcp: false, mtu: 1500}
+          - { vlanId: 30, dhcp: false, mtu: 1500 }
           - vlanId: 48
             dhcp: false
             mtu: 1500
@@ -215,17 +215,17 @@ apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
 provisioning:
-    diskSelector:
-        match: system_disk
-    maxSize: 10GiB
+  diskSelector:
+    match: system_disk
+  minSize: 100GiB
 ---
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-storage
 provisioning:
-    diskSelector:
-        match: disk.transport == "sata"
-    minSize: 25GiB
+  diskSelector:
+    match: disk.transport == "sata"
+  minSize: 100GiB
 ---
 apiVersion: v1alpha1
 kind: EthernetConfig

--- a/talos/static-configs/home02.yaml
+++ b/talos/static-configs/home02.yaml
@@ -77,7 +77,7 @@ machine:
       - interface: bond0
         bond:
           deviceSelectors:
-            - {hardwareAddr: "7c:83:34:*", driver: igc}
+            - { hardwareAddr: "7c:83:34:*", driver: igc }
           mode: 802.3ad
           xmitHashPolicy: layer3+4
           lacpRate: fast
@@ -92,11 +92,11 @@ machine:
           # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
           - network: "10.0.48.83/32"
             gateway: "0.0.0.0"
-          - network: "10.0.48.84/30"  # 84-87
+          - network: "10.0.48.84/30" # 84-87
             gateway: "0.0.0.0"
-          - network: "10.0.48.88/29"  # 88-95
+          - network: "10.0.48.88/29" # 88-95
             gateway: "0.0.0.0"
-          - network: "10.0.48.96/27"  # 96-127
+          - network: "10.0.48.96/27" # 96-127
             gateway: "0.0.0.0"
           - network: "10.0.48.128/26" # 128-191
             gateway: "0.0.0.0"
@@ -106,7 +106,7 @@ machine:
             gateway: "0.0.0.0"
         mtu: 1500
         vlans:
-          - {vlanId: 30, dhcp: false, mtu: 1500}
+          - { vlanId: 30, dhcp: false, mtu: 1500 }
           - vlanId: 48
             dhcp: false
             mtu: 1500
@@ -215,17 +215,17 @@ apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
 provisioning:
-    diskSelector:
-        match: system_disk
-    maxSize: 100GiB
+  diskSelector:
+    match: system_disk
+  maxSize: 200GiB
 ---
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-storage
 provisioning:
-    diskSelector:
-        match: disk.transport == "sata"
-    minSize: 25GiB
+  diskSelector:
+    match: disk.transport == "sata"
+  minSize: 100GiB
 ---
 apiVersion: v1alpha1
 kind: EthernetConfig

--- a/talos/static-configs/home03.yaml
+++ b/talos/static-configs/home03.yaml
@@ -87,11 +87,11 @@ machine:
           # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
           - network: "10.0.48.83/32"
             gateway: "0.0.0.0"
-          - network: "10.0.48.84/30"  # 84-87
+          - network: "10.0.48.84/30" # 84-87
             gateway: "0.0.0.0"
-          - network: "10.0.48.88/29"  # 88-95
+          - network: "10.0.48.88/29" # 88-95
             gateway: "0.0.0.0"
-          - network: "10.0.48.96/27"  # 96-127
+          - network: "10.0.48.96/27" # 96-127
             gateway: "0.0.0.0"
           - network: "10.0.48.128/26" # 128-191
             gateway: "0.0.0.0"
@@ -211,17 +211,17 @@ apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
 provisioning:
-    diskSelector:
-        match: system_disk
-    maxSize: 25GiB
+  diskSelector:
+    match: system_disk
+  minSize: 100GiB
 ---
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-storage
 provisioning:
-    diskSelector:
-        match: disk.transport == "sata"
-    minSize: 25GiB
+  diskSelector:
+    match: disk.transport == "sata"
+  minSize: 100GiB
 ---
 apiVersion: v1alpha1
 kind: EthernetConfig


### PR DESCRIPTION
This pull request updates storage provisioning settings across several Talos static configuration files and the Rook Ceph HelmRelease to broaden device selection and increase minimum/maximum disk sizes. The changes aim to ensure more storage devices are included and to provide larger disk allocations for both system and user volumes.

**Storage provisioning configuration updates:**

* Broadened the device path filter in `rook-ceph/cluster/helmrelease.yaml` to include all NVMe devices, instead of only specific models, allowing Rook Ceph to discover and use a wider range of NVMe disks.

**Disk size adjustments in Talos static configs:**

* Increased the minimum size requirement for system and user disks to 100GiB in `home01.yaml` and `home03.yaml`, ensuring larger disks are provisioned for both ephemeral and local storage volumes. [[1]](diffhunk://#diff-7f8736a9f7039f5afc8aac463fdabced47e4e9bff946e62a5d2ecfde50797cf8L220-R228) [[2]](diffhunk://#diff-82687849bea8c1ceff184ecc2b6f689a58b547d439fe00a16806ecf209d8a4c7L216-R224)
* Raised the maximum allowed size for system disks to 200GiB and increased the minimum size for user disks to 100GiB in `home02.yaml`, enabling support for larger disk volumes.