### PR TITLE
fix: more specific static bond for home05

### DIFF
--- a/talos/static-configs/home05.yaml
+++ b/talos/static-configs/home05.yaml
@@ -85,7 +85,8 @@ machine:
       - interface: bond0
         bond:
           deviceSelectors:
-            - hardwareAddr: 70:85:c2:d5:84:*
+            - { hardwareAddr: "70:85:c2:d5:84:9e", driver: igb } # enp2s0
+            - { hardwareAddr: "70:85:c2:d5:84:9c", driver: e1000e } # eno1
           mode: active-backup
           miimon: 100
           primary: enp2s0


### PR DESCRIPTION
This pull request updates the network bond configuration in `talos/static-configs/home05.yaml` to specify exact hardware addresses and drivers for the bonded interfaces, improving reliability and clarity.

Network configuration improvements:

* Changed the `bond.deviceSelectors` for `bond0` to explicitly list two interfaces with their full hardware addresses and associated drivers (`igb` for `enp2s0`, `e1000e` for `eno1`), replacing the previous wildcard selector.