### PR TITLE
fix: revert incorrect YAML formatting changes from PR #35

### DIFF
--- a/bootstrap/secrets.yaml.tpl
+++ b/bootstrap/secrets.yaml.tpl
@@ -4,6 +4,16 @@ kind: Namespace
 metadata:
   name: external-secrets
 ---
-# onepassword-secret is managed manually due to encoding issues
-# DO NOT add back to this template - it causes Groundhog Day encoding loops
-# Manual fix: kubectl create secret generic onepassword-secret --namespace external-secrets --from-literal="1password-credentials.json=$CREDS_DECODED" --from-literal="token=$TOKEN"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-secret
+  namespace: external-secrets
+type: Opaque
+stringData:
+  # IMPORTANT: 1Password Connect requires base64-encoded credentials
+  # The OP_CREDENTIALS_JSON field in 1Password is already base64 encoded
+  # Using stringData will base64 encode it again (double encoding as required)
+  # See: https://github.com/1Password/connect-helm-charts/issues/202
+  1password-credentials.json: op://homelab/1password/OP_CREDENTIALS_JSON
+  token: op://homelab/1password/OP_CONNECT_TOKEN

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
@@ -17,7 +17,7 @@ spec:
   enableSuperuserAccess: true
   postgresql:
     parameters:
-      max_connections: 200
+      max_connections: "200"
       shared_buffers: 256MB
   resources:
     requests:

--- a/kubernetes/apps/media/autobrr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/autobrr/app/externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
         AUTOBRR__DATABASE_TYPE: postgres
         AUTOBRR__POSTGRES_DATABASE: &dbName autobrr
         AUTOBRR__POSTGRES_HOST: &dbHost postgres-rw.databases.svc.cluster.local
-        AUTOBRR__POSTGRES_PORT: 5432
+        AUTOBRR__POSTGRES_PORT: "5432"
         AUTOBRR__POSTGRES_USER: &dbUser "{{ .AUTOBRR_POSTGRES_USER }}"
         AUTOBRR__POSTGRES_PASS: &dbPass "{{ .AUTOBRR_POSTGRES_PASS }}"
         AUTOBRR__SESSION_SECRET: "{{ .AUTOBRR_SESSION_SECRET }}"

--- a/kubernetes/apps/media/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autobrr/app/helmrelease.yaml
@@ -65,7 +65,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: { drop: [ALL] }
+              capabilities: { drop: ["ALL"] }
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       data:
         PROWLARR__AUTH__APIKEY: "{{ .PROWLARR_API_KEY }}"
         PROWLARR__POSTGRES__HOST: &dbHost postgres-rw.databases.svc.cluster.local
-        PROWLARR__POSTGRES__PORT: 5432
+        PROWLARR__POSTGRES__PORT: "5432"
         PROWLARR__POSTGRES__USER: &dbUser "{{ .PROWLARR_POSTGRES_USER }}"
         PROWLARR__POSTGRES__PASSWORD: &dbPass "{{ .PROWLARR_POSTGRES_PASS }}"
         PROWLARR__POSTGRES__MAINDB: prowlarr_main

--- a/kubernetes/apps/media/qbittorrent/tools/tqm/resources/config.yaml
+++ b/kubernetes/apps/media/qbittorrent/tools/tqm/resources/config.yaml
@@ -53,7 +53,7 @@ rules:
     filter:
       min_seed_time: "168h"
       max_ratio: 2.0
-      max_seed_time: 0
+      max_seed_time: "0"
     actions:
       - name: delete
         delete_files: true
@@ -78,7 +78,7 @@ rules:
     filter:
       min_seed_time: "720h"
       max_ratio: 0
-      max_seed_time: 0
+      max_seed_time: "0"
     actions:
       - name: delete
         delete_files: true

--- a/kubernetes/apps/media/radarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/radarr/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       data:
         RADARR__AUTH__APIKEY: "{{ .RADARR_API_KEY }}"
         RADARR__POSTGRES__HOST: &dbHost postgres-rw.databases.svc.cluster.local
-        RADARR__POSTGRES__PORT: 5432
+        RADARR__POSTGRES__PORT: "5432"
         RADARR__POSTGRES__USER: &dbUser "{{ .RADARR_POSTGRES_USER }}"
         RADARR__POSTGRES__PASSWORD: &dbPass "{{ .RADARR_POSTGRES_PASS }}"
         RADARR__POSTGRES__MAINDB: radarr_main

--- a/kubernetes/apps/media/sonarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sonarr/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       data:
         SONARR__AUTH__APIKEY: "{{ .SONARR_API_KEY }}"
         SONARR__POSTGRES__HOST: &dbHost postgres-rw.databases.svc.cluster.local
-        SONARR__POSTGRES__PORT: 5432
+        SONARR__POSTGRES__PORT: "5432"
         SONARR__POSTGRES__USER: &dbUser "{{ .SONARR_POSTGRES_USER }}"
         SONARR__POSTGRES__PASSWORD: &dbPass "{{ .SONARR_POSTGRES_PASS }}"
         SONARR__POSTGRES__MAINDB: sonarr_main

--- a/kubernetes/components/nfs-scaler/scaledobject.yaml
+++ b/kubernetes/components/nfs-scaler/scaledobject.yaml
@@ -16,5 +16,5 @@ spec:
       metadata:
         serverAddress: http://prometheus-operated.observability.svc.cluster.local:9090
         query: probe_success{instance=~".+:2049"}
-        threshold: 1
-        ignoreNullValues: 0
+        threshold: "1"
+        ignoreNullValues: "0"


### PR DESCRIPTION
This pull request primarily focuses on standardizing the formatting of numeric configuration values by converting several integer values to strings across Kubernetes manifests and configuration files. Additionally, it introduces a managed `onepassword-secret` resource to the `external-secrets` namespace, replacing manual secret creation. These changes improve consistency, prevent encoding issues, and align with best practices for Kubernetes and external tool integrations.

**Secret management improvements**
* Added a managed `onepassword-secret` of kind `Secret` to `bootstrap/secrets.yaml.tpl`, with guidance on double base64 encoding for 1Password Connect compatibility, replacing previous manual instructions.

**Configuration consistency (numeric values as strings)**
* Updated all relevant `POSTGRES_PORT` values to be strings in the `externalsecret.yaml` files for `autobrr`, `prowlarr`, `radarr`, and `sonarr` apps to ensure type consistency for environment variables. [[1]](diffhunk://#diff-7e5d326fc162fb6c138a29c38334af192f5d1e38f31dc930c93200ce804505daL18-R18) [[2]](diffhunk://#diff-325f3372d2a022b983f077e36e46abf9bafabe32c74ee373f5ca7c89dd3c4e20L17-R17) [[3]](diffhunk://#diff-f99faa91a624c4f11bd1f76da470b07f430372ab98f0788f286999a5a534a3f7L17-R17) [[4]](diffhunk://#diff-f2d1d68215d5389b716d9e23360aaebdd1d44af849061bb5e517a82be187f382L17-R17)
* Changed `max_connections` in `cluster.yaml` for the cloudnative-pg cluster to a string value for consistency with expected input types.
* Updated `threshold` and `ignoreNullValues` to strings in the NFS scaler `scaledobject.yaml` to match expected configuration formats.

**Configuration consistency (array values as strings)**
* Changed the `capabilities.drop` value from `[ALL]` to `["ALL"]` in the `helmrelease.yaml` for `autobrr` to ensure proper YAML array formatting.

**Configuration consistency (other numeric values as strings)**
* Updated `max_seed_time` from integer to string in two filter rules in the `qbittorrent` TQM config to maintain type consistency. [[1]](diffhunk://#diff-c789b8b3af0d3cb2620a874aae41ee4a401a792662dfb70c60d8e19392316c81L56-R56) [[2]](diffhunk://#diff-c789b8b3af0d3cb2620a874aae41ee4a401a792662dfb70c60d8e19392316c81L81-R81)