### PR TITLE
fix: CloudNative-PG ExternalSecret boolean to string

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/externalsecret.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/externalsecret.yaml
@@ -18,7 +18,7 @@ spec:
         AWS_SECRET_ACCESS_KEY: "{{ .S3_SECRET_ACCESS_KEY }}"
       metadata:
         labels:
-          cnpg.io/reload: true
+          cnpg.io/reload: "true"
   dataFrom:
     - extract:
         key: seaweedfs


### PR DESCRIPTION
This pull request makes a minor change to the `externalsecret.yaml` file for the CloudNativePG database cluster. The change corrects the value of the `cnpg.io/reload` label to be a string instead of a boolean.