### PR TITLE
fix: quote Rook-Ceph StorageClass imageFormat parameter

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -103,7 +103,7 @@ spec:
           reclaimPolicy: Delete
           allowVolumeExpansion: true
           parameters:
-            imageFormat: 2
+            imageFormat: "2"
             imageFeatures: layering,exclusive-lock,object-map,fast-diff,deep-flatten
             csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
             csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
Fix imageFormat: 2 -> imageFormat: "2" in StorageClass parameters. Kubernetes StorageClass parameters must be strings, not numbers.

This was another remnant from PR #35 that incorrectly unquoted numeric values.

Resolves HelmRelease error:
"StorageClass.parameters of type string: json: cannot unmarshal number"