### PR TITLE
fix: exclude home05 from Ceph storage using node labels

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -86,9 +86,18 @@ spec:
         connections:
           requireMsgr2: true
       storage:
-        useAllNodes: true
+        useAllNodes: false
         useAllDevices: false
-        devicePathFilter: /dev/disk/by-id/nvme-*
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: ceph-storage
+                    operator: In
+                    values:
+                      - enabled
+        config:
+          osdsPerDevice: "1"
     cephBlockPools:
       - name: ceph-blockpool
         spec:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -98,6 +98,7 @@ spec:
                       - enabled
         config:
           osdsPerDevice: "1"
+          devicePathFilter: /dev/disk/by-id/nvme-*
     cephBlockPools:
       - name: ceph-blockpool
         spec:


### PR DESCRIPTION
This pull request updates the Rook Ceph cluster Helm release configuration to improve control over storage node selection and device usage. The main changes restrict Ceph storage to specific nodes using node affinity and refine device selection and OSD configuration.

**Storage node selection and device configuration:**

* Changed `useAllNodes` from `true` to `false`, so Ceph will not use all cluster nodes for storage, improving control over where storage is provisioned.
* Added a `nodeAffinity` section to ensure that only nodes labeled with `ceph-storage=enabled` are selected for Ceph storage, enforcing targeted scheduling.
* Removed the broad `devicePathFilter` and replaced it with a more specific configuration, including setting `osdsPerDevice` to `"1"` for finer control over OSD provisioning per device.