### PR TITLE
fix: update Ceph devicePathFilter to use deviceFilter regex

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
       storage:
         useAllNodes: true
         useAllDevices: false
-        devicePathFilter: /dev/disk/by-id/nvme-*
+        deviceFilter: "^nvme[0-9]+n[0-9]+$"
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:


### PR DESCRIPTION
## Summary
- Fixed Ceph OSD creation issue by changing devicePathFilter to deviceFilter with regex
- Changed from `/dev/disk/by-id/nvme-*` to `^nvme[0-9]+n[0-9]+$` pattern  
- Addresses issue where no OSDs were being created despite available NVMe devices

## Root Cause
The original `devicePathFilter: /dev/disk/by-id/nvme-*` was too restrictive and didn't match actual NVMe device paths in the cluster. This resulted in:
- 0 OSDs created across all nodes
- Ceph cluster in HEALTH_WARN state  
- Block pool in Failure status

## Solution
- Switched to `deviceFilter` with regex pattern `^nvme[0-9]+n[0-9]+$`
- This directly matches NVMe device names (e.g., nvme0n1, nvme1n1)
- More reliable than path-based filtering

## Test Plan
- [x] Verified NVMe devices are visible with `lsblk`
- [x] Confirmed nodes have `ceph-storage=enabled` labels
- [ ] Monitor OSD creation after deployment
- [ ] Verify Ceph cluster health becomes HEALTH_OK

🤖 Generated with [Claude Code](https://claude.ai/code)