### PR TITLE
fix: quote string values in YAML configurations

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   configuration:
     data:
-      compression: bzip2
-    destinationPath: s3://postgres-backup/
-    endpointURL: https://s3.hypyr.space
+      compression: "bzip2"
+    destinationPath: "s3://postgres-backup/"
+    endpointURL: "https://s3.hypyr.space"
     s3Credentials:
       accessKeyId:
         name: cloudnative-pg-secret
@@ -17,6 +17,6 @@ spec:
         name: cloudnative-pg-secret
         key: AWS_SECRET_ACCESS_KEY
     wal:
-      compression: bzip2
+      compression: "bzip2"
       maxParallel: 8
-  retentionPolicy: 30d
+  retentionPolicy: "30d"

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -31,7 +31,7 @@ spec:
           value: warning
           matchType: =
   receivers:
-    - name: null
+    - name: "null"
     - name: heartbeat
       webhookConfigs:
         - urlSecret:

--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
         configs:
           - from: "2024-04-01" # quote
             store: "tsdb"
-            object_store: "filesystem" 
+            object_store: "filesystem"
             schema: "v13"
             index:
               prefix: loki_index_

--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -43,31 +43,31 @@ spec:
         delete_request_store: filesystem
         retention_enabled: true
       ingester:
-        chunk_encoding: snappy
+        chunk_encoding: "snappy"
       limits_config:
-        retention_period: 14d
+        retention_period: "14d"
       schemaConfig:
         configs:
           - from: "2024-04-01" # quote
-            store: tsdb
-            object_store: filesystem
-            schema: v13
+            store: "tsdb"
+            object_store: "filesystem" 
+            schema: "v13"
             index:
               prefix: loki_index_
-              period: 24h
+              period: "24h"
       server:
         grpc_server_max_recv_msg_size: 10485760 # 10 MiB
         grpc_server_max_send_msg_size: 10485760 # 10 MiB
-        log_level: info
+        log_level: "info"
       storage:
-        type: filesystem
+        type: "filesystem"
       structuredConfig:
         ruler:
           enable_api: true
           enable_alertmanager_v2: true
           alertmanager_url: http://alertmanager-operated.observability.svc.cluster.local:9093
           storage:
-            type: local
+            type: "local"
             local:
               directory: /rules
           rule_path: /rules/fake


### PR DESCRIPTION
This pull request standardizes the formatting of configuration values in several Kubernetes YAML files by consistently quoting string values. This helps prevent parsing issues and ensures clarity when values might be interpreted ambiguously (such as numbers or keywords). The changes affect database, observability, and logging configurations.

**Configuration value quoting:**

* In `kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml`, all string values under `compression`, `destinationPath`, `endpointURL`, and `retentionPolicy` are now quoted to ensure proper YAML parsing. [[1]](diffhunk://#diff-aabc64dce6c0853f120993729fffa93e7aec0a101f617c7b5ac5aa09146d0596L9-R11) [[2]](diffhunk://#diff-aabc64dce6c0853f120993729fffa93e7aec0a101f617c7b5ac5aa09146d0596L20-R22)
* In `kubernetes/apps/observability/loki/app/helmrelease.yaml`, string values for fields like `chunk_encoding`, `retention_period`, `store`, `object_store`, `schema`, `period`, `log_level`, `type`, and `structuredConfig.ruler.storage.type` are now quoted for consistency and correctness.
* In `kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml`, the receiver name `null` is now quoted to avoid potential issues with YAML interpreting it as a special value.