### PR TITLE
fix: quote additional string values across all namespaces

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
@@ -18,7 +18,7 @@ spec:
   postgresql:
     parameters:
       max_connections: "200"
-      shared_buffers: 256MB
+      shared_buffers: "256MB"
   resources:
     requests:
       cpu: 300m
@@ -32,7 +32,7 @@ spec:
       isWALArchiver: true
       parameters: &parameters
         barmanObjectName: s3
-        serverName: postgres-v23
+        serverName: "postgres-v23"
   # Note: uncomment bootstrap section when recovering from an existing cluster
   # bootstrap:
   #   recovery:

--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -43,7 +43,7 @@ ipv4NativeRoutingCIDR: 10.244.0.0/16
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 7445
 kubeProxyReplacement: true
-kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
+kubeProxyReplacementHealthzBindAddr: "0.0.0.0:10256"
 l2announcements:
   enabled: true
 loadBalancer:

--- a/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
@@ -8,7 +8,7 @@ serviceAccount:
   create: true
 service:
   name: kube-dns
-  clusterIP: 10.96.0.10
+  clusterIP: "10.96.0.10"
 servers:
   - zones:
       - zone: .
@@ -37,7 +37,7 @@ servers:
       - name: reload
       - name: loadbalance
       - name: prometheus
-        parameters: 0.0.0.0:9153
+        parameters: "0.0.0.0:9153"
       - name: log
         configBlock: |-
           class error

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
               repository: ghcr.io/home-operations/plex
               tag: 1.41.9.9961@sha256:6c86319bb3275135f5da5aec71b45e48305669ecbceee0f88d335bebf0d0f218 # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             env:
-              PLEX_ADVERTISE_URL: https://{{ .Release.Name }}.hypyr.space:443
-              PLEX_NO_AUTH_NETWORKS: 192.168.2.0/24
+              PLEX_ADVERTISE_URL: "https://{{ .Release.Name }}.hypyr.space:443"
+              PLEX_NO_AUTH_NETWORKS: "192.168.2.0/24"
               TZ: America/Chicago
             probes:
               liveness: &probes

--- a/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
               - --domain-filter=hypyr.space
               - --events
               - --gateway-name=external
-              - --interval=10m
+              - "--interval=10m"
               - --log-format=text
               - --log-level=info
               - --policy=sync

--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
     localpv-provisioner:
       localpv:
         image:
-          registry: quay.io/
+          registry: "quay.io/"
         basePath: &basePath /var/mnt/local-storage
         analytics:
           enabled: false
@@ -46,7 +46,7 @@ spec:
         volumeBindingMode: Immediate
       helperPod:
         image:
-          registry: quay.io/
+          registry: "quay.io/"
     openebs-crds:
       csi:
         volumeSnapshots:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           enabled: true
       dashboard:
         enabled: true
-        urlPrefix: /
+        urlPrefix: "/"
         ssl: false
         prometheusEndpoint: http://prometheus-operated.observability.svc.cluster.local:9090
       mgr:


### PR DESCRIPTION
This pull request standardizes the formatting of several string values in Kubernetes YAML configuration files by consistently quoting values. This improves YAML parsing reliability and prevents type inference issues, especially for values that could be misinterpreted as numbers or booleans.

**Quoting configuration values for consistency and reliability:**

* Database configuration: Quoted values for `shared_buffers` and `serverName` in `cluster.yaml` to ensure they are interpreted as strings. [[1]](diffhunk://#diff-362f213a852a50ecc534095dd0636c5fe7374d6276b27b5ef76ee7b828bea542L21-R21) [[2]](diffhunk://#diff-362f213a852a50ecc534095dd0636c5fe7374d6276b27b5ef76ee7b828bea542L35-R35)
* Networking and service configuration: Quoted IP addresses and port values in `cilium` and `coredns` Helm values files to prevent misinterpretation. [[1]](diffhunk://#diff-ddc39da0791f883c8a3f4fa10cbea6c85903f70a7c49b0a53bf2c86116a12f03L46-R46) [[2]](diffhunk://#diff-c69ca6ae86be5c0686777ad40d125fc515cb67711856d9bdb11357ffbd7ea206L11-R11)
* Service parameters: Quoted parameters for `prometheus` in `coredns` and `interval` in `external-dns` to maintain type consistency. [[1]](diffhunk://#diff-c69ca6ae86be5c0686777ad40d125fc515cb67711856d9bdb11357ffbd7ea206L40-R40) [[2]](diffhunk://#diff-ea30ff14c06b03c496e10c1fc9f755a9f27eef864ee2a97de7920148adafc0bbL35-R35)
* Application environment variables: Quoted `PLEX_ADVERTISE_URL` and `PLEX_NO_AUTH_NETWORKS` in `plex` HelmRelease to avoid parsing errors.
* Storage and dashboard configuration: Quoted registry URLs in `openebs` and `urlPrefix` in `rook-ceph` to ensure proper string handling. [[1]](diffhunk://#diff-46e7bd52f093e81b577502d5921dff94041963d78154986674b4d84bc3a6fef1L37-R37) [[2]](diffhunk://#diff-46e7bd52f093e81b577502d5921dff94041963d78154986674b4d84bc3a6fef1L49-R49) [[3]](diffhunk://#diff-170514720b1e813566b0ce574498dd98fbb33ab1e6bf2d1a048da4e46b336e82L77-R77)