### PR TITLE
fix(github-actions): convert ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER to …

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
               - /home/runner/run.sh
             env:
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
-                value: false
+                value: "false"
               - name: NODE
                 valueFrom:
                   fieldRef:


### PR DESCRIPTION
This pull request makes a minor update to the runner configuration by quoting the boolean value for the `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER` environment variable. This change ensures the value is interpreted as a string rather than a native boolean, which can help prevent type-related issues in YAML parsing.