### PR TITLE
fix(plex): remove PLEX_NO_AUTH_NETWORKS env variable and update transcode configuration

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -26,7 +26,6 @@ spec:
               tag: 1.41.9.9961@sha256:6c86319bb3275135f5da5aec71b45e48305669ecbceee0f88d335bebf0d0f218 # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             env:
               PLEX_ADVERTISE_URL: https://{{ .Release.Name }}.hypyr.space:443
-              PLEX_NO_AUTH_NETWORKS: 192.168.2.0/24
               TZ: America/Chicago
             probes:
               liveness: &probes
@@ -85,6 +84,14 @@ spec:
         globalMounts:
           - path: /data
             readOnly: true
+      transcode:
+        # TODO: Move back to tmpfs (emptyDir) when nodes have sufficient memory for transcoding
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 50Gi
+        storageClass: openebs-hostpath
+        globalMounts:
+          - path: /transcode
       tmpfs:
         type: emptyDir
         advancedMounts:
@@ -92,8 +99,6 @@ spec:
             app:
               - path: /config/Library/Application Support/Plex Media Server/Logs
                 subPath: logs
-              - path: /transcode
-                subPath: transcode
               - path: /tmp
                 subPath: tmp
       dri:


### PR DESCRIPTION
This pull request updates the configuration for the Plex media server deployment in Kubernetes, focusing on storage management for transcoding and network authentication settings. The most important changes are outlined below.

**Storage and Transcoding Configuration:**

* The `/transcode` directory is now mounted using a `persistentVolumeClaim` with `ReadWriteOnce` access, a size of 50Gi, and the `openebs-hostpath` storage class. This replaces the previous `emptyDir` (tmpfs) mount, providing more reliable storage for transcoding tasks.
* The previous advanced mount for `/transcode` under the `tmpfs` configuration has been removed, reflecting the shift to persistent storage.

**Network Authentication:**

* The `PLEX_NO_AUTH_NETWORKS` environment variable, which previously allowed unauthenticated access from the `192.168.2.0/24` network, has been removed to tighten security.