### PR TITLE
feat(media): suspend recyclarr

### DIFF
--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -5,7 +5,7 @@ metadata:
   name: &app recyclarr
   namespace: &namespace media
 spec:
-  suspend: true
+  suspend: true # TODO: I may pull this out completely, there are some easier to use alternatives. as it is the config isn't complete and I'll fix it later
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -5,6 +5,7 @@ metadata:
   name: &app recyclarr
   namespace: &namespace media
 spec:
+  suspend: true
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app


### PR DESCRIPTION
This pull request makes a minor configuration change to the `recyclarr` Kubernetes deployment. The change suspends the associated job or cronjob, preventing it from running until re-enabled.

* Set `suspend: true` in the `spec` section of `kubernetes/apps/media/recyclarr/ks.yaml`, pausing execution of the workload.