### PR TITLE
fix(volsync): remove duplicate runAsUser/runAsGroup keys and quote template variables

### DIFF
--- a/kubernetes/components/volsync/seaweedfs/replicationdestination.yaml
+++ b/kubernetes/components/volsync/seaweedfs/replicationdestination.yaml
@@ -17,9 +17,9 @@ spec:
     accessModes: ["${VOLSYNC_ACCESSMODES:=ReadWriteOnce}"]
     capacity: "${VOLSYNC_CAPACITY:=5Gi}"
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_PUID:=568}
-      runAsGroup: ${VOLSYNC_PGID:=568}
-      fsGroup: ${VOLSYNC_PGID:=568}
+      runAsUser: "${VOLSYNC_PUID:=568}"
+      runAsGroup: "${VOLSYNC_PGID:=568}"
+      fsGroup: "${VOLSYNC_PGID:=568}"
     enableFileDeletion: true
     cleanupCachePVC: true
     cleanupTempPVC: true

--- a/kubernetes/components/volsync/seaweedfs/replicationsource.yaml
+++ b/kubernetes/components/volsync/seaweedfs/replicationsource.yaml
@@ -18,8 +18,6 @@ spec:
     storageClassName: "${VOLSYNC_STORAGECLASS:=ceph-block}"
     accessModes: ["${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}"]
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_PUID:=568}
-      runAsGroup: ${VOLSYNC_PGID:=568}
       runAsUser: "${VOLSYNC_PUID:=568}"
       runAsGroup: "${VOLSYNC_PGID:=568}"
       fsGroup: "${VOLSYNC_PGID:=568}"


### PR DESCRIPTION
## Summary

- Fixed duplicate runAsUser/runAsGroup keys in `seaweedfs/replicationsource.yaml`
- Quoted all template variables in `seaweedfs/replicationdestination.yaml` for consistency
- Resolves YAML unmarshal errors preventing app deployments

## Root Cause

The `kubernetes/components/volsync/seaweedfs/replicationsource.yaml` file contained duplicate `runAsUser` and `runAsGroup` keys in the `moverSecurityContext` section:

```yaml
moverSecurityContext:
  runAsUser: ${VOLSYNC_PUID:=568}      # unquoted
  runAsGroup: ${VOLSYNC_PGID:=568}     # unquoted
  runAsUser: "${VOLSYNC_PUID:=568}"    # quoted - DUPLICATE!
  runAsGroup: "${VOLSYNC_PGID:=568}"   # quoted - DUPLICATE!
```

This caused flux-local and Flux to fail with:
```
post build failed for '${APP}': yaml: unmarshal errors:
  line 23: mapping key "runAsUser" already defined at line 21
  line 24: mapping key "runAsGroup" already defined at line 22
```

## Changes Made

1. **seaweedfs/replicationsource.yaml**: Removed duplicate keys, kept only properly quoted versions
2. **seaweedfs/replicationdestination.yaml**: Quoted template variables for consistency

## Impact

This fixes the deployment failures for all applications using volsync components:
- zigbee2mqtt, home-assistant (default namespace)  
- bazarr, maintainerr, overseerr, plex, prowlarr, tautulli (media namespace)

🤖 Generated with [Claude Code](https://claude.ai/code)