### PR TITLE
fix(atuin): remove invalid image SHA digest

### DIFF
--- a/kubernetes/apps/default/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/atuin/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
           app:
             image:
               repository: ghcr.io/atuinsh/atuin
-              tag: v18.8.0@sha256:8a8a8ef4eb5865656072bace5cc49390b56caa81360f9f0869054777155b6ef1
+              tag: v18.8.0
             env:
               ATUIN_DB_URI: sqlite:///config/atuin.db
               ATUIN_HOST: 0.0.0.0


### PR DESCRIPTION
## Summary

Remove invalid SHA digest from atuin image configuration that was causing image pull failures.

## Issue

The atuin deployment was failing with:
```
Failed to pull image "ghcr.io/atuinsh/atuin:v18.8.0@sha256:8a8a8ef4eb5865656072bace5cc49390b56caa81360f9f0869054777155b6ef1": 
rpc error: code = NotFound desc = failed to pull and unpack image
```

## Fix

- Remove invalid SHA digest `@sha256:8a8a8ef4eb5865656072bace5cc49390b56caa81360f9f0869054777155b6ef1`
- Use tag-only reference `v18.8.0` (latest version)
- Allows Docker to pull the correct image successfully

## Test Results

✅ Atuin pod now running successfully (1/1 Ready)
✅ Service created with correct ports
✅ PVC bound with volsync integration

🤖 Generated with [Claude Code](https://claude.ai/code)