### PR TITLE
fix(zigbee2mqtt): quote KEDA ScaledObject integer metadata values

### DIFF
--- a/kubernetes/apps/default/zigbee2mqtt/app/scaledobject.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/scaledobject.yaml
@@ -16,5 +16,5 @@ spec:
       metadata:
         serverAddress: http://prometheus-operated.observability.svc.cluster.local:9090
         query: probe_success{instance=~"zigbee-controller.+"}
-        threshold: 1
-        ignoreNullValues: 0
+        threshold: "1"
+        ignoreNullValues: "0"


### PR DESCRIPTION
This pull request updates the configuration values for the Zigbee2MQTT Kubernetes ScaledObject to ensure compatibility and consistency in value types.

Configuration update:

* Changed the values of `threshold` and `ignoreNullValues` in `kubernetes/apps/default/zigbee2mqtt/app/scaledobject.yaml` from integers to strings to match expected types.