### PR TITLE
fix(postgres): add schema permissions to bootstrap script

### DIFF
--- a/scripts/bootstrap-postgres-users.sh
+++ b/scripts/bootstrap-postgres-users.sh
@@ -193,6 +193,10 @@ create_user_and_database() {
     execute_sql "GRANT ALL PRIVILEGES ON DATABASE \"$username\" TO \"$username\";" \
         "Grant permissions to $username"
 
+    # Grant schema permissions (required for PostgreSQL 15+)
+    execute_sql "GRANT ALL ON SCHEMA public TO \"$username\";" \
+        "Grant schema permissions to $username"
+
     # Set default privileges for future objects
     execute_sql "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO \"$username\";" \
         "Set default table privileges for $username"


### PR DESCRIPTION
PostgreSQL 15+ requires explicit schema permissions for users to create tables and other objects. The bootstrap script was only granting database permissions but missing schema permissions.

This adds 'GRANT ALL ON SCHEMA public TO user' to ensure all database users can properly access their schemas for table creation, etc.

Also applied retroactive fix to all existing database users in cluster.

Resolves schema permission errors like:
  pq: permission denied for schema public

🤖 Generated with [Claude Code](https://claude.ai/code)