### PR TITLE
fix(networking): create consistent bond0 interface naming across all nodes

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -22,7 +22,7 @@ cni:
   exclusive: false
 dashboards:
   enabled: true
-devices: bond0,eno1,enp2s0
+devices: bond0,enp2s0
 enableIPv4BIGTCP: true
 endpointRoutes:
   enabled: true

--- a/kubernetes/apps/kube-system/cilium/config/l2.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/l2.yaml
@@ -6,8 +6,7 @@ metadata:
 spec:
   loadBalancerIPs: true
   interfaces:
-    - bond0.48 # Using VLAN 48 interface for service announcements
-    - eno1.48
+    - bond0.48 # Using VLAN 48 interface for service announcements (bond on home01/home02, bridge on home03)
     - enp2s0.48 # Added for home05 single interface setup
   nodeSelector:
     matchLabels:

--- a/talos/static-configs/home03.yaml
+++ b/talos/static-configs/home03.yaml
@@ -78,6 +78,13 @@ machine:
     interfaces:
       - interface: eno1
         dhcp: false
+        mtu: 1500
+      - interface: bond0
+        bridge:
+          stp:
+            enabled: false
+          interfaces:
+            - eno1
         addresses: ["10.0.5.100/24"]
         routes:
           - network: "0.0.0.0/0"


### PR DESCRIPTION
## Summary

Resolves Home Assistant multus network configuration issues by creating consistent interface naming across heterogeneous hardware.

## Problem

- **home01/home02**: Use `bond0.30` (bonded interfaces)
- **home03**: Uses `eno1.30` (single interface)
- **multus-iot**: Hardcoded for `bond0.30` causing failures on home03

```
Failed to create pod sandbox: plugin type="macvlan" failed (add): Link not found
```

## Solution: Interface Aliasing via Bridge

Create bridge interface `bond0` on home03 that bridges to `eno1`, providing consistent naming across all nodes.

## Changes

### Talos Configuration (home03)
- ✅ Add bridge interface `bond0` bridging to `eno1`
- ✅ Move network config (IP, routes, VLANs) from `eno1` to `bond0`
- ✅ Creates `bond0.30` matching other nodes

### Kubernetes Networking  
- ✅ Keep unified `multus-iot` network using `bond0.30`
- ✅ Home Assistant reverted to standard network config
- ✅ Remove Cilium hardcoded `eno1` references

### Cilium Updates
- ✅ L2 Policy: Remove `eno1.48`, use `bond0.48` consistently  
- ✅ Device detection: Remove `eno1` from device list

## Result

- **Consistent** `bond0.30` interface on all nodes regardless of hardware
- **Scalable** approach for future mixed-hardware deployments
- **Home Assistant** can schedule anywhere using same network config
- **No node pinning** required - natural scheduler placement

## Testing

After merge and Talos config application:
1. home03 will have `bond0.30` (bridge)
2. Home Assistant pod should recreate successfully on any node
3. VLAN 30 connectivity preserved across cluster

🤖 Generated with [Claude Code](https://claude.ai/code)