### PR TITLE
fix(networking,talos): update TALOS_ENDPOINTS and reduce external-dns frequency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Applications have explicit dependencies managed by Flux:
 ### Key Variables (Taskfile.yaml)
 
 - **CONTROL_PLANE_ENDPOINT**: `https://homeops.hypyr.space:6443` (Points to kube-vip LoadBalancer: 10.0.48.55)
-- **TALOS_ENDPOINTS**: `10.0.5.215,10.0.5.220,10.0.5.118`
+- **TALOS_ENDPOINTS**: `10.0.5.215,10.0.5.220,10.0.5.100`
 - **TALOS_NODES**: Dynamically extracted from `talos/node-mapping.yaml` (currently: 3 nodes)
 - **OP_VAULT**: `homelab` (1Password vault)
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,7 +10,7 @@ vars:
   TALOS_DIR: "{{.ROOT_DIR}}/talos"
   CONTROL_PLANE_ENDPOINT: "https://homeops.hypyr.space:6443"
   OP_VAULT: "homelab"
-  TALOS_ENDPOINTS: "10.0.5.215,10.0.5.220,10.0.5.118"
+  TALOS_ENDPOINTS: "10.0.5.215,10.0.5.220,10.0.5.100"
   TALOS_NODES:
     sh: yq '.nodes | keys | join(",")' {{.TALOS_DIR}}/node-mapping.yaml
 

--- a/kubernetes/apps/media/cross-seed/ks.yaml
+++ b/kubernetes/apps/media/cross-seed/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app cross-seed
   namespace: &namespace media
 spec:
+  # TODO: Remove suspend when VPN configuration is properly set up for torrent client dependencies
+  suspend: true
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app qbittorrent
   namespace: &namespace media
 spec:
+  # TODO: Remove suspend when VPN configuration is properly set up for torrent client
+  suspend: true
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
@@ -42,6 +44,8 @@ metadata:
   name: &app qbittorrent-tools
   namespace: &namespace media
 spec:
+  # TODO: Remove suspend when VPN configuration is properly set up for torrent client
+  suspend: true
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app

--- a/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -72,8 +72,7 @@ spec:
               tag: v0.18.0@sha256:f90738b35be265d50141d5c21e6f6049c3da7cd761682c40214117a2951b80bc # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             args:
               - --domain-filter=hypyr.space
-              - --events
-              - --interval=10m
+              - --interval=5m
               - --log-format=text
               - --log-level=info
               - --policy=sync

--- a/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -72,6 +72,7 @@ spec:
               tag: v0.18.0@sha256:f90738b35be265d50141d5c21e6f6049c3da7cd761682c40214117a2951b80bc # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             args:
               - --domain-filter=hypyr.space
+              # TODO: Re-evaluate --events flag and interval once cluster stabilizes - UniFi gateway currently unhappy with frequency
               - --interval=5m
               - --log-format=text
               - --log-level=info


### PR DESCRIPTION
## Summary
- Update TALOS_ENDPOINTS to use correct home03 IP (10.0.5.100) after networking changes
- Remove --events flag from external-dns-unifi to prevent immediate reactions to every HTTPRoute/Service change
- Set external-dns-unifi interval to 5m to reduce frequency of UniFi gateway updates
- Suspend cross-seed and qbittorrent pending VPN configuration

## Changes
- **Taskfile.yaml**: Updated TALOS_ENDPOINTS from 10.0.5.118 to 10.0.5.100 for home03
- **CLAUDE.md**: Updated documentation to reflect correct endpoint
- **external-dns-unifi**: Removed --events flag and set 5-minute interval to reduce UniFi gateway impact
- **Torrent apps**: Suspended cross-seed and qbittorrent until VPN is configured

## Test Plan
- [x] Verify cluster connectivity with updated TALOS_ENDPOINTS
- [x] Test kubectl access
- [x] Confirm external DNS will update every 5 minutes instead of on every change

🤖 Generated with [Claude Code](https://claude.ai/code)