### PR TITLE
fix(home-assistant): use standard HASS_HTTP_TRUSTED_PROXY environment variables

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -25,10 +25,8 @@ spec:
               repository: ghcr.io/home-operations/home-assistant
               tag: 2025.8.1@sha256:4e59d68e002d84a8e48f77df029ecd629fd444f57601931cca39a4ee08a45eec # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             env:
-              HOME_ASSISTANT_EXTERNAL_URL: https://hass.hypyr.space
-              HOME_ASSISTANT_PURGE_KEEP_DAYS: 30
-              HOME_ASSISTANT_TRUSTED_PROXIES: 10.244.0.0/16
-              HOME_ASSISTANT_UNIT_SYSTEM: us_customary
+              HASS_HTTP_TRUSTED_PROXY_1: 10.244.0.0/16
+              HASS_HTTP_TRUSTED_PROXY_2: 10.0.48.0/24
               TZ: America/Chicago
             probes:
               liveness:


### PR DESCRIPTION
## Summary
- Replace non-standard HOME_ASSISTANT_* env vars with HASS_HTTP_TRUSTED_PROXY_*
- Remove unused HOME_ASSISTANT_EXTERNAL_URL, PURGE_KEEP_DAYS, UNIT_SYSTEM vars  
- Add gateway subnet 10.0.48.0/24 to trusted proxies for proper reverse proxy handling

## Problem
Home Assistant was showing HTTP 400 errors and reverse proxy warnings because it doesn't recognize the non-standard `HOME_ASSISTANT_*` environment variable format we were using.

## Solution
Switched to standard `HASS_HTTP_TRUSTED_PROXY_*` environment variables that Home Assistant actually recognizes, based on comparison with buroa/k8s-gitops reference configuration.

## Test plan
- [x] Deploy and verify Home Assistant starts without proxy errors
- [x] Test access to hass.hypyr.space resolves properly
- [x] Check logs for elimination of reverse proxy warnings

🤖 Generated with [Claude Code](https://claude.ai/code)