### PR TITLE
feat(scripts): rename and expand bootstrap-media-secrets to bootstrap-app-secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ task volsync:restore APP=<name> PREVIOUS=<snapshot>  # Restore from backup
 task setup-cloudflare-tunnel                  # Configure tunnel for external service access
 
 # Secret management
-task bootstrap-media-secrets                  # Bootstrap API keys for media services
+task bootstrap-app-secrets                    # Bootstrap API keys for application services
 ```
 
 ### Development Environment

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -39,9 +39,9 @@ tasks:
       - which cloudflared
       - which jq
 
-  bootstrap-media-secrets:
-    desc: Bootstrap API keys for media services (solves chicken/egg problem)
-    cmd: ./scripts/bootstrap-media-secrets.sh
+  bootstrap-app-secrets:
+    desc: Bootstrap API keys for application services (solves chicken/egg problem)
+    cmd: ./scripts/bootstrap-app-secrets.sh
     preconditions:
       - op user get --me
       - kubectl cluster-info


### PR DESCRIPTION
## Summary
- Rename `bootstrap-media-secrets.sh` → `bootstrap-app-secrets.sh` for broader scope
- Add zigbee2mqtt support with MQTT_USER and MQTT_PASSWORD fields
- Replace confusing parallel arrays with clear associative array for service-namespace mapping
- Update all documentation and task references from "media secrets" to "app secrets"
- Remove duplicate namespaces in sync mapping

## Problem
- Script was misnamed as "media secrets" when it handles all application services
- Missing zigbee2mqtt support was causing deployment failures with "secret not found" errors
- Parallel arrays for services/namespaces were error-prone and had duplicates

## Solution
- Broader naming reflects actual scope (media, monitoring, home automation, etc.)
- Added zigbee2mqtt with MQTT credentials that match expected ExternalSecret fields
- Associative array makes service-to-namespace mapping clear and maintainable
- Updated all references consistently across codebase

## Test plan
- [x] Verify script syntax and function renaming
- [x] Check task command updates in Taskfile.yaml
- [x] Validate documentation updates in CLAUDE.md
- [ ] Run script to test zigbee2mqtt secret creation
- [ ] Verify zigbee2mqtt deployment succeeds after secret sync

🤖 Generated with [Claude Code](https://claude.ai/code)