### PR TITLE
fix(networking): improve Cilium stability based on buroa's configuration

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -47,8 +47,8 @@ kubeProxyReplacementHealthzBindAddr: "0.0.0.0:10256"
 l2announcements:
   enabled: true
 loadBalancer:
-  algorithm: maglev
-  mode: dsr
+  algorithm: round_robin
+  mode: snat
 localRedirectPolicy: true
 operator:
   replicas: 2

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.17.5
+    tag: 1.18.0
   url: oci://ghcr.io/home-operations/charts-mirror/cilium
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/kube-system/cilium/config/l2.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/l2.yaml
@@ -6,8 +6,7 @@ metadata:
 spec:
   loadBalancerIPs: true
   interfaces:
-    - bond0.48 # Using VLAN 48 interface for service announcements (bond on home01/home02, bridge on home03)
-    - enp2s0.48 # Added for home05 single interface setup
+    - bond0.48 # Using VLAN 48 interface for service announcements
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux

--- a/kubernetes/apps/kube-system/cilium/config/pool.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/pool.yaml
@@ -4,7 +4,7 @@ kind: CiliumLoadBalancerIPPool
 metadata:
   name: lb-pool
 spec:
-  allowFirstLastIPs: "Yes"
+  allowFirstLastIPs: "No"
   blocks:
     # Using VLAN 48 network for LoadBalancer services
     - start: 10.0.48.50


### PR DESCRIPTION
This pull request updates the configuration for Cilium in the Kubernetes cluster, focusing on load balancer behavior, IP pool settings, and Helm chart version upgrades. The main changes improve load balancing algorithms and modes, restrict IP pool allocations, and update resource versions for better compatibility and stability.

**Load balancer configuration changes:**

* Changed the load balancer algorithm from `maglev` to `round_robin` and the mode from `dsr` to `snat` in `values.yaml`, which affects how traffic is distributed and handled.

**IP pool and network interface adjustments:**

* Updated the `allowFirstLastIPs` setting in the load balancer IP pool from `"Yes"` to `"No"`, preventing allocation of the first and last IPs in each block for safer networking.
* Removed the `enp2s0.48` interface from the L2 service announcement configuration, standardizing on `bond0.48` for VLAN 48 announcements.

**Helm chart version upgrade:**

* Upgraded the Cilium Helm chart reference from tag `1.17.5` to `1.18.0` in `helmrelease.yaml`, ensuring the deployment uses the latest features and fixes.