### PR TITLE
fix(observability): update snmp-exporter ExternalSecret to stable v1 API

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: snmp-truenas-secret


### PR DESCRIPTION
## Summary
- Update snmp-exporter ExternalSecret from deprecated `external-secrets.io/v1beta1` to stable `external-secrets.io/v1` API
- Ensures compatibility with current External Secrets Operator version
- Resolves API version deprecation warnings during cluster reconciliation

## Changes
- `kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml`: Updated apiVersion to `external-secrets.io/v1`

## Test plan
- [x] Verified API version against External Secrets Operator documentation via Context7
- [x] Configuration maintains existing SNMP v3 credential structure for TrueNAS monitoring
- [x] No functional changes to SNMP monitoring behavior

🤖 Generated with [Claude Code](https://claude.ai/code)