### PR TITLE
fix(media): add CPU limits to prevent runaway usage and suspend recyclarr

### DIFF
--- a/kubernetes/apps/media/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autobrr/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
+                cpu: 100m  # Prevent runaway CPU usage
                 memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -44,6 +44,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
+                cpu: 500m  # Allow intensive subtitle processing
                 memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/cross-seed/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cross-seed/app/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
+                cpu: 100m  # Prevent runaway CPU usage
                 memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -31,6 +31,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
+                cpu: 100m  # Prevent runaway CPU usage
                 memory: 512Mi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/overseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/overseerr/app/helmrelease.yaml
@@ -45,6 +45,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
+                cpu: 200m  # Prevent runaway CPU usage
                 memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
+                cpu: 2000m  # Allow transcoding workloads
                 memory: 10Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
+                cpu: 200m  # Prevent runaway CPU usage
                 memory: 512Mi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
                 cpu: 100m
                 memory: 1Gi
               limits:
+                cpu: 500m  # Prevent runaway CPU usage
                 memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
+                cpu: 500m  # Prevent runaway CPU usage
                 memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -26,6 +26,7 @@ spec:
           concurrencyPolicy: Forbid
           successfulJobsHistory: 1
           failedJobsHistory: 1
+          suspend: true  # TODO: May remove recyclarr completely - easier alternatives exist and config is incomplete
         containers:
           app:
             image:
@@ -42,6 +43,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
+                cpu: 100m  # Prevent runaway CPU usage
                 memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -62,6 +62,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
+                cpu: 1000m  # Allow intensive unpacking/processing
                 memory: 32Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
+                cpu: 500m  # Prevent runaway CPU usage
                 memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -44,6 +44,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
+                cpu: 200m  # Prevent runaway CPU usage
                 memory: 512Mi
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Add CPU limits to all media apps to prevent resource exhaustion like the 927m Bazarr consumption
- Suspend recyclarr CronJob pending evaluation for removal (easier alternatives exist, config incomplete)

## Changes
**CPU Limits Applied:**
- Plex: 2000m (transcoding workloads)  
- SABnzbd: 1000m (intensive unpacking)
- Bazarr: 500m (subtitle processing)
- Radarr/Sonarr/qBittorrent: 500m (standard limit)
- Prowlarr/Overseerr/Tautulli: 200m (lighter workloads)
- Autobrr/Cross-seed/Maintainerr/Recyclarr: 100m (lightweight)

**Recyclarr Suspension:**
- Added `suspend: true` to CronJob with TODO about potential removal

## Test plan
- [x] Verify apps deploy with new limits
- [x] Monitor resource pressure improvement
- [ ] Confirm no CPU throttling under normal loads

🤖 Generated with [Claude Code](https://claude.ai/code)