### PR TITLE
chore(task): added kube tasks

### DIFF
--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -86,3 +86,183 @@ tasks:
       - flux -n actions-runner-system reconcile hr home-ops-runner
     preconditions:
       - which flux helm
+
+  suspend-namespace:
+    desc: Suspend all Flux Kustomizations in a namespace [NAMESPACE=required]
+    summary: |
+      Suspend all Flux Kustomizations in a namespace to stop reconciliation.
+
+      Usage: task kubernetes:suspend-namespace NAMESPACE=media
+
+      Note: This only prevents future reconciliation - existing pods remain until manually deleted.
+    requires:
+      vars: [NAMESPACE]
+    cmds:
+      - |
+        echo "Suspending all Kustomizations in namespace: {{.NAMESPACE}}"
+        kubectl get kustomizations -n {{.NAMESPACE}} --no-headers -o custom-columns=":metadata.name" | \
+        xargs -I {} flux suspend kustomization {} -n {{.NAMESPACE}}
+      - echo "✅ All Kustomizations in {{.NAMESPACE}} namespace suspended"
+
+  resume-namespace:
+    desc: Resume all Flux Kustomizations in a namespace [NAMESPACE=required]
+    summary: |
+      Resume all Flux Kustomizations in a namespace to restore reconciliation.
+
+      Usage: task kubernetes:resume-namespace NAMESPACE=media
+    requires:
+      vars: [NAMESPACE]
+    cmds:
+      - |
+        echo "Resuming all Kustomizations in namespace: {{.NAMESPACE}}"
+        kubectl get kustomizations -n {{.NAMESPACE}} --no-headers -o custom-columns=":metadata.name" | \
+        xargs -I {} flux resume kustomization {} -n {{.NAMESPACE}}
+      - echo "✅ All Kustomizations in {{.NAMESPACE}} namespace resumed"
+
+  delete-namespace-pods:
+    desc: Delete all pods in a namespace [NAMESPACE=required]
+    summary: |
+      Delete all pods in a namespace to free resources immediately.
+
+      Usage: task kubernetes:delete-namespace-pods NAMESPACE=media
+
+      Warning: This forcefully deletes all pods in the namespace.
+    requires:
+      vars: [NAMESPACE]
+    cmds:
+      - |
+        echo "⚠️  WARNING: This will delete ALL pods in namespace: {{.NAMESPACE}}"
+        read -p "Are you sure? (y/N): " confirm
+        if [[ $confirm == [yY] ]]; then
+          kubectl delete pods -n {{.NAMESPACE}} --all --grace-period=0 --force
+          echo "✅ All pods in {{.NAMESPACE}} namespace deleted"
+        else
+          echo "❌ Operation cancelled"
+        fi
+
+  delete-deployment:
+    desc: Delete a specific deployment and its pods [DEPLOYMENT=required NAMESPACE=required]
+    summary: |
+      Delete a specific deployment and all its pods.
+
+      Usage: task kubernetes:delete-deployment DEPLOYMENT=autobrr NAMESPACE=media
+    requires:
+      vars: [DEPLOYMENT, NAMESPACE]
+    cmds:
+      - |
+        echo "Deleting deployment: {{.DEPLOYMENT}} in namespace: {{.NAMESPACE}}"
+        kubectl delete deployment {{.DEPLOYMENT}} -n {{.NAMESPACE}} --grace-period=0 --force
+        echo "✅ Deployment {{.DEPLOYMENT}} deleted from {{.NAMESPACE}} namespace"
+
+  nuke-namespace:
+    desc: Nuclear option - suspend kustomizations AND delete all pods [NAMESPACE=required]
+    summary: |
+      Nuclear option: Suspend all Flux Kustomizations AND delete all pods in namespace.
+
+      Usage: task kubernetes:nuke-namespace NAMESPACE=media
+
+      Warning: This completely stops and cleans a namespace.
+    requires:
+      vars: [NAMESPACE]
+    cmds:
+      - |
+        echo "🚨 NUCLEAR OPTION: This will suspend all Kustomizations AND delete all pods in: {{.NAMESPACE}}"
+        read -p "Are you absolutely sure? (type 'NUKE' to confirm): " confirm
+        if [[ $confirm == "NUKE" ]]; then
+          task kubernetes:suspend-namespace NAMESPACE={{.NAMESPACE}}
+          sleep 2
+          kubectl delete pods -n {{.NAMESPACE}} --all --grace-period=0 --force
+          echo "💥 Namespace {{.NAMESPACE}} has been nuked"
+        else
+          echo "❌ Operation cancelled"
+        fi
+
+  scale-deployment:
+    desc: Scale a deployment to specific replica count [DEPLOYMENT=required NAMESPACE=required REPLICAS=required]
+    summary: |
+      Scale a deployment to a specific number of replicas.
+
+      Usage: task kubernetes:scale-deployment DEPLOYMENT=autobrr NAMESPACE=media REPLICAS=0
+    requires:
+      vars: [DEPLOYMENT, NAMESPACE, REPLICAS]
+    cmds:
+      - |
+        echo "Scaling deployment {{.DEPLOYMENT}} in {{.NAMESPACE}} to {{.REPLICAS}} replicas"
+        kubectl scale deployment {{.DEPLOYMENT}} -n {{.NAMESPACE}} --replicas={{.REPLICAS}}
+        echo "✅ Deployment {{.DEPLOYMENT}} scaled to {{.REPLICAS}} replicas"
+
+  restart-deployment:
+    desc: Restart a deployment by rolling it out [DEPLOYMENT=required NAMESPACE=required]
+    summary: |
+      Restart a deployment by triggering a rollout restart.
+
+      Usage: task kubernetes:restart-deployment DEPLOYMENT=autobrr NAMESPACE=media
+    requires:
+      vars: [DEPLOYMENT, NAMESPACE]
+    cmds:
+      - |
+        echo "Restarting deployment: {{.DEPLOYMENT}} in namespace: {{.NAMESPACE}}"
+        kubectl rollout restart deployment {{.DEPLOYMENT}} -n {{.NAMESPACE}}
+        echo "✅ Deployment {{.DEPLOYMENT}} restart initiated"
+        kubectl rollout status deployment {{.DEPLOYMENT}} -n {{.NAMESPACE}} --timeout=300s
+
+  check-resource-pressure:
+    desc: Check cluster resource pressure and identify constraining pods
+    summary: |
+      Check cluster resource pressure and identify pods consuming the most resources.
+    cmds:
+      - |
+        set +e  # Disable exit on error to handle SIGPIPE gracefully
+        echo "📊 Cluster Resource Pressure Analysis"
+        echo "======================================"
+        echo ""
+        echo "🖥️  Node Resource Usage:"
+        if ! kubectl top nodes 2>/dev/null; then
+          echo "❌ Failed to get node metrics"
+          exit 1
+        fi
+        echo ""
+        echo "🔥 Top 10 CPU Consuming Pods:"
+        cpu_output=$(kubectl top pods -A --sort-by=cpu 2>/dev/null)
+        if [[ $? -eq 0 && -n "$cpu_output" ]]; then
+          echo "$cpu_output" | head -11
+        else
+          echo "❌ Failed to get pod CPU metrics"
+          exit 1
+        fi
+        echo ""
+        echo "💾 Top 10 Memory Consuming Pods:"
+        memory_output=$(kubectl top pods -A --sort-by=memory 2>/dev/null)
+        if [[ $? -eq 0 && -n "$memory_output" ]]; then
+          echo "$memory_output" | head -11
+        else
+          echo "❌ Failed to get pod memory metrics"
+          exit 1
+        fi
+        echo ""
+        echo "⚠️  Problematic Pods:"
+        problematic_pods=$(kubectl get pods -A 2>/dev/null | grep -E "(Pending|CrashLoopBackOff|Error|ImagePullBackOff)" || true)
+        if [[ -n "$problematic_pods" ]]; then
+          echo "$problematic_pods"
+        else
+          echo "✅ No problematic pods found"
+        fi
+        echo ""
+        echo "📋 Summary:"
+        total_pods=$(kubectl get pods -A --no-headers 2>/dev/null | wc -l || echo "unknown")
+        running_pods=$(kubectl get pods -A --no-headers 2>/dev/null | grep -c "Running" || echo "unknown")
+        echo "Total pods: $total_pods | Running: $running_pods"
+
+  force-pod-delete:
+    desc: Force delete a stuck pod [POD=required NAMESPACE=required]
+    summary: |
+      Force delete a stuck pod with grace period 0.
+
+      Usage: task kubernetes:force-pod-delete POD=autobrr-xyz NAMESPACE=media
+    requires:
+      vars: [POD, NAMESPACE]
+    cmds:
+      - |
+        echo "Force deleting pod: {{.POD}} in namespace: {{.NAMESPACE}}"
+        kubectl delete pod {{.POD}} -n {{.NAMESPACE}} --grace-period=0 --force
+        echo "✅ Pod {{.POD}} force deleted"


### PR DESCRIPTION
This pull request adds several new operational tasks to the Kubernetes Taskfile, making it easier to manage namespaces, deployments, and pods, as well as to diagnose cluster resource pressure. These additions provide more granular control over Flux Kustomizations, pod lifecycle management, and resource troubleshooting directly from the task runner.

Namespace and Kustomization management:

* Added `suspend-namespace` and `resume-namespace` tasks to suspend or resume all Flux Kustomizations in a specified namespace, allowing for quick pausing or resumption of reconciliation processes.
* Introduced the `nuke-namespace` task, which combines suspending all Kustomizations and force-deleting all pods in a namespace for a complete cleanup.

Pod and deployment lifecycle operations:

* Added `delete-namespace-pods` and `delete-deployment` tasks to forcefully delete all pods in a namespace or a specific deployment and its pods, providing immediate resource release.
* Implemented `scale-deployment` and `restart-deployment` tasks for scaling deployments to a specific replica count and rolling out restarts, improving deployment management.
* Added `force-pod-delete` to forcefully remove stuck pods with zero grace period.

Resource monitoring and troubleshooting:

* Added `check-resource-pressure`