### PR TITLE
fix(media): allow Plex scheduling on home03 and reduce memory limits

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -48,9 +48,10 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 4Gi
               limits:
                 cpu: 2000m  # Allow transcoding workloads
-                memory: 10Gi
+                memory: 6Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -63,7 +64,7 @@ spec:
               - matchExpressions:
                   - key: quicksync.generation
                     operator: In
-                    values: ["9", "10", "11", "12"]
+                    values: ["7", "9", "10", "11", "12"]
       securityContext:
         runAsNonRoot: true
         runAsUser: 568


### PR DESCRIPTION
## Summary
- Add QuickSync generation 7 to node affinity to include home03 node
- Reduce memory request to 4Gi and limit to 6Gi for current cluster capacity
- Add memory request to ensure proper resource allocation

## Problem
Plex was failing to schedule due to:
1. Node affinity excluding home03 (generation 7 QuickSync)
2. 10Gi memory limit exceeding available cluster resources

## Solution
- Updated node affinity to include generations 7, 9-12
- Reduced memory requirements to fit current 3-node cluster
- Added explicit memory request for better scheduling

🤖 Generated with [Claude Code](https://claude.ai/code)