### PR TITLE
feat(media): standardize ports and add hostUsers security setting

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/barman-cloud/helmrelease.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/barman-cloud/helmrelease.yaml
@@ -68,6 +68,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
             "namespace": "networking",
             "ips": ["10.0.30.200/24"]
           }]
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/default/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/helmrelease.yaml
@@ -74,6 +74,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
@@ -110,6 +110,7 @@ spec:
             resources: *resources
             securityContext: *securityContext
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/kubernetes/apps/media/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autobrr/app/helmrelease.yaml
@@ -62,6 +62,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/cross-seed/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cross-seed/app/helmrelease.yaml
@@ -59,6 +59,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               tag: 2.18.2@sha256:f0ad693314830eade8df47df348bae50e1639002cf9158f54f6d149772fb0f53 # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             env:
               TZ: America/Chicago
-              UI_PORT: &port 6246
+              UI_PORT: &port 80
             resources:
               requests:
                 cpu: 10m
@@ -38,6 +38,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/overseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/overseerr/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               tag: 1.34.0@sha256:4f38f58d68555004d3f487a4c5cbe2823e6a0942d946a25a2d9391d8492240a4 # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             env:
               LOG_LEVEL: info
-              PORT: &port 5055
+              PORT: &port 80
               TZ: America/Chicago
             probes:
               liveness: &probes
@@ -52,6 +52,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -65,6 +65,7 @@ spec:
                   - key: quicksync.generation
                     operator: In
                     values: ["7", "9", "10", "11", "12"]
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -68,6 +68,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -58,6 +58,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/qbittorrent/tools/qbr/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/tools/qbr/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
         pod:
           restartPolicy: OnFailure
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/qbittorrent/tools/tqm/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/tools/tqm/helmrelease.yaml
@@ -45,6 +45,7 @@ spec:
         pod:
           restartPolicy: OnFailure
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -68,6 +68,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -50,6 +50,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -69,6 +69,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -68,6 +68,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
@@ -63,6 +63,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/networking/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/echo-server/app/helmrelease.yaml
@@ -54,6 +54,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
@@ -70,6 +70,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -101,6 +101,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/networking/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/smtp-relay/app/helmrelease.yaml
@@ -50,6 +50,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -79,6 +79,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -58,6 +58,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
@@ -42,6 +42,7 @@ spec:
         serviceAccount:
           name: *app
     defaultPodOptions:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568


### PR DESCRIPTION
## Summary

- Standardize Overseerr port from 5055 to 80 following buroa pattern
- Standardize Maintainerr port from 6246 to 80 following buroa pattern  
- Add hostUsers: false to all 29 apps using readOnlyRootFilesystem
- Improves filesystem permission handling in containers
- Aligns with established security patterns from buroa/k8s-gitops

## Details

### Port Standardization
- **Overseerr**: Changed  → 
- **Maintainerr**: Changed  → 

This follows the pattern used by buroa/k8s-gitops where all media apps use port 80 for consistency and easier management.

### Security Enhancement
Added  to all applications using :

**Media Apps (14 files):**
- autobrr, bazarr, cross-seed, maintainerr, overseerr, plex, prowlarr, qbittorrent, radarr, recyclarr, sabnzbd, sonarr, tautulli
- Plus qbittorrent tools: qbr, tqm

**Other Apps (15 files):**
- Default: home-assistant, mosquitto, zigbee2mqtt
- Networking: cloudflared, echo-server, external-dns (2), smtp-relay
- Observability: gatus, karma, kromgo, unpoller
- System: onepassword, system-upgrade-controller, barman-cloud

### Benefits
- **Improved filesystem permissions** - hostUsers: false helps resolve permission issues in containers
- **Consistent security posture** - All readOnlyRootFilesystem apps now have the same security pattern
- **Alignment with best practices** - Following established patterns from buroa/k8s-gitops
- **Simplified port management** - Standardized ports reduce complexity

🤖 Generated with [Claude Code](https://claude.ai/code)