### PR TITLE
fix(media): reduce resource limits to prevent continuous rebuilding

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -60,6 +60,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 cpu: 200m  # Prevent runaway CPU usage
                 memory: 512Mi

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -61,9 +61,10 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1Gi
               limits:
                 cpu: 1000m  # Allow intensive unpacking/processing
-                memory: 32Gi
+                memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary
- Reduce sabnzbd memory limit from 32Gi to 4Gi to prevent resource exhaustion
- Add memory request (1Gi) to sabnzbd for better scheduling 
- Add memory request (256Mi) to prowlarr for explicit resource allocation
- Resolves continuous pod rebuilding caused by insufficient cluster resources

## Problem
Services in the media namespace were continually rebuilding due to resource constraints. qbittorrent was requesting 32Gi memory and sabnzbd was requesting 32Gi memory, exceeding available node capacity (~30Gi per node).

## Solution  
- Scaled torrent services (qbittorrent, autobrr) to zero as requested
- Reduced sabnzbd memory limits to reasonable levels for download extraction
- Added explicit memory requests for better Kubernetes scheduling
- Maintained prowlarr and sabnzbd operation as essential services

## Test plan
- [x] Verify pods can schedule with new resource limits
- [x] Confirm sabnzbd and prowlarr are running normally
- [x] Check torrent services remain scaled to zero

🤖 Generated with [Claude Code](https://claude.ai/code)