### PR TITLE
fix(media): set maintainerr BASE_PATH to serve from root

### DIFF
--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -27,6 +27,7 @@ spec:
             env:
               TZ: America/Chicago
               UI_PORT: &port 80
+              BASE_PATH: "/"
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Summary
- Add BASE_PATH: '/' environment variable to maintainerr configuration
- Fixes proxy path configuration for proper routing from root path

## Problem
Maintainerr was not serving from the root path (/), causing proxy routing issues when accessing the application through ingress/gateway.

## Solution
Added the BASE_PATH environment variable set to "/" to explicitly configure maintainerr to serve from the root path instead of defaulting to a subdirectory.

## Configuration Change
```yaml
env:
  TZ: America/Chicago
  UI_PORT: &port 80
  BASE_PATH: "/"  # Added this line
```

## Test plan
- [x] Verify maintainerr serves correctly from root path
- [x] Confirm proxy routing works as expected
- [x] Check application accessibility through configured hostname

🤖 Generated with [Claude Code](https://claude.ai/code)