### PR TITLE
fix(networking): upgrade Cilium L2 API to v2 and remove blackhole routes

### DIFF
--- a/kubernetes/apps/kube-system/cilium/config/l2.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/l2.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumL2AnnouncementPolicy
 metadata:
   name: l2-policy

--- a/kubernetes/apps/kube-system/cilium/config/pool.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/pool.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: lb-pool

--- a/talos/static-configs/home01.yaml
+++ b/talos/static-configs/home01.yaml
@@ -87,23 +87,6 @@ machine:
         routes:
           - network: "0.0.0.0/0"
             gateway: "10.0.5.1"
-          # Selective blackhole routes - exclude critical cluster endpoints
-          # Allow: 10.0.48.50-10.0.48.82 (kube-vip: 55, external: 80, internal: 81, qbit: 82)
-          # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
-          - network: "10.0.48.83/32"
-            gateway: "0.0.0.0"
-          - network: "10.0.48.84/30" # 84-87
-            gateway: "0.0.0.0"
-          - network: "10.0.48.88/29" # 88-95
-            gateway: "0.0.0.0"
-          - network: "10.0.48.96/27" # 96-127
-            gateway: "0.0.0.0"
-          - network: "10.0.48.128/26" # 128-191
-            gateway: "0.0.0.0"
-          - network: "10.0.48.192/29" # 192-199
-            gateway: "0.0.0.0"
-          - network: "10.0.48.200/32" # 200
-            gateway: "0.0.0.0"
         mtu: 1500
         vlans:
           - { vlanId: 30, dhcp: false, mtu: 1500 }

--- a/talos/static-configs/home02.yaml
+++ b/talos/static-configs/home02.yaml
@@ -87,23 +87,6 @@ machine:
         routes:
           - network: "0.0.0.0/0"
             gateway: "10.0.5.1"
-          # Selective blackhole routes - exclude critical cluster endpoints
-          # Allow: 10.0.48.50-10.0.48.82 (kube-vip: 55, external: 80, internal: 81, qbit: 82)
-          # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
-          - network: "10.0.48.83/32"
-            gateway: "0.0.0.0"
-          - network: "10.0.48.84/30" # 84-87
-            gateway: "0.0.0.0"
-          - network: "10.0.48.88/29" # 88-95
-            gateway: "0.0.0.0"
-          - network: "10.0.48.96/27" # 96-127
-            gateway: "0.0.0.0"
-          - network: "10.0.48.128/26" # 128-191
-            gateway: "0.0.0.0"
-          - network: "10.0.48.192/29" # 192-199
-            gateway: "0.0.0.0"
-          - network: "10.0.48.200/32" # 200
-            gateway: "0.0.0.0"
         mtu: 1500
         vlans:
           - { vlanId: 30, dhcp: false, mtu: 1500 }

--- a/talos/static-configs/home03.yaml
+++ b/talos/static-configs/home03.yaml
@@ -89,23 +89,6 @@ machine:
         routes:
           - network: "0.0.0.0/0"
             gateway: "10.0.5.1"
-          # Selective blackhole routes - exclude critical cluster endpoints
-          # Allow: 10.0.48.50-10.0.48.82 (kube-vip: 55, external: 80, internal: 81, qbit: 82)
-          # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
-          - network: "10.0.48.83/32"
-            gateway: "0.0.0.0"
-          - network: "10.0.48.84/30" # 84-87
-            gateway: "0.0.0.0"
-          - network: "10.0.48.88/29" # 88-95
-            gateway: "0.0.0.0"
-          - network: "10.0.48.96/27" # 96-127
-            gateway: "0.0.0.0"
-          - network: "10.0.48.128/26" # 128-191
-            gateway: "0.0.0.0"
-          - network: "10.0.48.192/29" # 192-199
-            gateway: "0.0.0.0"
-          - network: "10.0.48.200/32" # 200
-            gateway: "0.0.0.0"
         mtu: 1500
         vlans:
           - vlanId: 30

--- a/talos/static-configs/home04.yaml
+++ b/talos/static-configs/home04.yaml
@@ -94,23 +94,6 @@ machine:
         routes:
           - network: "0.0.0.0/0"
             gateway: "10.0.5.1"
-          # Selective blackhole routes - exclude critical cluster endpoints
-          # Allow: 10.0.48.50-10.0.48.82 (kube-vip: 55, external: 80, internal: 81, qbit: 82)
-          # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
-          - network: "10.0.48.83/32"
-            gateway: "0.0.0.0"
-          - network: "10.0.48.84/30" # 84-87
-            gateway: "0.0.0.0"
-          - network: "10.0.48.88/29" # 88-95
-            gateway: "0.0.0.0"
-          - network: "10.0.48.96/27" # 96-127
-            gateway: "0.0.0.0"
-          - network: "10.0.48.128/26" # 128-191
-            gateway: "0.0.0.0"
-          - network: "10.0.48.192/29" # 192-199
-            gateway: "0.0.0.0"
-          - network: "10.0.48.200/32" # 200
-            gateway: "0.0.0.0"
         mtu: 1500
         vlans:
           - vlanId: 30


### PR DESCRIPTION
## Summary
• Update CiliumLoadBalancerIPPool and CiliumL2AnnouncementPolicy from v2alpha1 to v2
• Remove blackhole routes from all Talos node configurations (home01-04)
• Align with buroa/k8s-gitops Cilium 1.18.0 configuration patterns

## Motivation
Following buroa's working Cilium 1.18.0 setup:
- API version upgrade from v2alpha1 to stable v2 improves L2 announcement reliability
- Blackhole routes were interfering with L2 announcements on bond0.48 VLAN interface
- Buroa doesn't use blackhole routes, letting network handle unused IPs naturally

## Test plan
- [x] All 4 nodes remain healthy after config changes
- [x] etcd cluster stable during rolling changes
- [ ] External L2 announcement connectivity working
- [ ] LoadBalancer services accessible from local network

🤖 Generated with [Claude Code](https://claude.ai/code)