### PR TITLE
fix(networking): correct L2AnnouncementPolicy API to v2alpha1

### DIFF
--- a/kubernetes/apps/kube-system/cilium/config/l2.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/l2.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cilium.io/v2
+apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy
 metadata:
   name: l2-policy


### PR DESCRIPTION
## Summary
Correct CiliumL2AnnouncementPolicy API version from v2 to v2alpha1

## Problem
Previous PR #145 attempted to upgrade both Cilium resources to v2 API, but:
- ✅ CiliumLoadBalancerIPPool supports v2 API (working)
- ❌ CiliumL2AnnouncementPolicy only supports v2alpha1 in Cilium 1.18.0

## Solution
Revert only the L2AnnouncementPolicy back to the correct v2alpha1 API version.

## Test plan
- [ ] L2 announcements work properly with correct API version
- [ ] External LoadBalancer connectivity restored

🤖 Generated with [Claude Code](https://claude.ai/code)