### PR TITLE
chore(flux): add health checks and remove wait from cilium kustomizations

### DIFF
--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -8,6 +8,11 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/app
   prune: true
@@ -18,7 +23,6 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -42,7 +46,6 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -70,4 +73,3 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true


### PR DESCRIPTION
## Summary
Following buroa/k8s-gitops patterns for Cilium Kustomizations:
- Add healthChecks targeting HelmRelease resources
- Remove `wait: true` for improved deployment flow

## Changes
• Added healthChecks section to cilium Kustomization
• Removed `wait: true` from all three Cilium Kustomizations (cilium, cilium-config, cilium-gateway)

## Reference
Based on buroa commit: https://github.com/buroa/k8s-gitops/commit/c2d9c22d6734bcaa0754878d21c9712727937b19

🤖 Generated with [Claude Code](https://claude.ai/code)