### PR TITLE
chore(flux): remove wait: true from core kustomizations

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -18,7 +18,6 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -46,4 +45,3 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -18,7 +18,6 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -49,4 +48,3 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -18,4 +18,3 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true

--- a/kubernetes/apps/external-secrets/onepassword/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/ks.yaml
@@ -21,7 +21,6 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -50,4 +49,3 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
-  wait: true


### PR DESCRIPTION
## Summary
Remove `wait: true` from core infrastructure Kustomizations following buroa/k8s-gitops patterns.

## Changes
• **actions-runner-controller**: Remove wait from controller and runners Kustomizations
• **cert-manager**: Remove wait from cert-manager and issuers Kustomizations  
• **external-secrets**: Remove wait from external-secrets Kustomization
• **onepassword**: Remove wait from onepassword and store Kustomizations

## Benefits
- Improves deployment flow by reducing blocking behavior
- Allows Flux to manage reconciliation timing more efficiently
- Aligns with buroa's proven GitOps patterns

## Reference
Based on buroa commit: https://github.com/buroa/k8s-gitops/commit/0f9a96ec478e21bd0e3a6749631e42be7015d125

🤖 Generated with [Claude Code](https://claude.ai/code)