### PR TITLE
feat(network): update network configuration to use bonding

### DIFF
--- a/talos/static-configs/home05.yaml
+++ b/talos/static-configs/home05.yaml
@@ -82,31 +82,18 @@ machine:
     disableManifestsDirectory: true
   network:
     interfaces:
-      - deviceSelector:
-          hardwareAddr: "70:85:c2:d5:84:9e"
-          driver: igb
+      - interface: bond0
+        bond:
+          interfaces: ["eno1", "enp2s0"]
+          mode: 802.3ad
+          xmitHashPolicy: layer3+4
+          lacpRate: fast
+          miimon: 5000
         addresses:
           - 10.0.5.129/24
         routes:
           - network: "0.0.0.0/0"
             gateway: "10.0.5.1"
-          # Selective blackhole routes - exclude critical cluster endpoints
-          # Allow: 10.0.48.50-10.0.48.82 (kube-vip: 55, external: 80, internal: 81, qbit: 82)
-          # Blackhole: 10.0.48.83-10.0.48.200 (remaining LoadBalancer pool)
-          - network: "10.0.48.83/32"
-            gateway: "0.0.0.0"
-          - network: "10.0.48.84/30" # 84-87
-            gateway: "0.0.0.0"
-          - network: "10.0.48.88/29" # 88-95
-            gateway: "0.0.0.0"
-          - network: "10.0.48.96/27" # 96-127
-            gateway: "0.0.0.0"
-          - network: "10.0.48.128/26" # 128-191
-            gateway: "0.0.0.0"
-          - network: "10.0.48.192/29" # 192-199
-            gateway: "0.0.0.0"
-          - network: "10.0.48.200/32" # 200
-            gateway: "0.0.0.0"
         mtu: 1500
         vlans:
           - { vlanId: 30, dhcp: false, mtu: 1500 }


### PR DESCRIPTION
This pull request updates the network configuration for `home05.yaml`, specifically changing the way network interfaces are defined and managed. The main change is the replacement of a single physical interface with a bonded interface for improved redundancy and throughput, and the removal of several selective blackhole routes.

**Network interface configuration changes:**

* Replaced the previous physical interface definition (using `deviceSelector` for a specific MAC address and driver) with a bonded interface `bond0` that combines `eno1` and `enp2s0`, using 802.3ad (LACP) mode for link aggregation.
* Configured bonding options such as `xmitHashPolicy`, `lacpRate`, and `miimon` for the new bonded interface.

**Routing changes:**

* Removed selective blackhole routes that previously excluded critical cluster endpoints and blackholed the remaining LoadBalancer pool IP ranges.

**Other configuration updates:**

* Retained the address, default route, MTU, and VLAN configuration under the new bonded interface structure.