### PR TITLE
feat(renovate): add Kubernetes and Talos grouping with coordinated updates

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,15 +2,15 @@
 KUBECONFIG = '{{config_root}}/kubernetes/kubeconfig'
 MINIJINJA_CONFIG_FILE = '{{config_root}}/.minijinja.toml'
 TALOSCONFIG = '{{config_root}}/talos/talosconfig'
-TALOS_VERSION = "v1.10.5"
-KUBERNETES_VERSION = "v1.33.2"
+TALOS_VERSION = "v1.11.0-beta.2"
+KUBERNETES_VERSION = "v1.33.4"
 MACHINE_TYPE = "controlplane"
 TALOS_SCHEMATIC = "b4e204a2932be8827ddf98a9329269723407f77b36a758400506bca4abebc602"
 
 [tools]
 helmfile = "1.1.5"
 kubectl = "1.33.4"
-talosctl = "1.10.6"
+talosctl = "1.11.0-beta.2"
 task = "3.44.0"
 "cargo:minijinja-cli" = "latest"
 "cargo:jinja-lsp" = "latest"

--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -15,5 +15,55 @@
       ],
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
     },
+    {
+      customType: "regex",
+      description: "Process mise.toml version variables",
+      managerFilePatterns: ["\\.mise\\.toml$"],
+      matchStrings: [
+        "TALOS_VERSION = \"(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\""
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "siderolabs/talos",
+    },
+    {
+      customType: "regex", 
+      description: "Process mise.toml Kubernetes version variables",
+      managerFilePatterns: ["\\.mise\\.toml$"],
+      matchStrings: [
+        "KUBERNETES_VERSION = \"(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\""
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "kubernetes/kubernetes",
+    },
+    {
+      customType: "regex",
+      description: "Process mise.toml talosctl tool versions",
+      managerFilePatterns: ["\\.mise\\.toml$"],
+      matchStrings: [
+        "talosctl = \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\""
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "siderolabs/talos",
+    },
+    {
+      customType: "regex",
+      description: "Process mise.toml kubectl tool versions",
+      managerFilePatterns: ["\\.mise\\.toml$"],
+      matchStrings: [
+        "kubectl = \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\""
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "kubernetes/kubernetes",
+    },
+    {
+      customType: "regex",
+      description: "Process mise.toml flux2 tool versions",
+      managerFilePatterns: ["\\.mise\\.toml$"],
+      matchStrings: [
+        "flux2 = \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\""
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "fluxcd/flux2",
+    },
   ],
 }

--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -61,8 +61,9 @@
     {
       description: "Flux Operator Group",
       groupName: "Flux Operator",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/flux-operator/", "/flux-instance/"],
+      matchDatasources: ["docker", "github-releases"],
+      matchPackageNames: ["/flux-operator/", "/flux-instance/", "fluxcd/flux2"],
+      matchFileNames: [".mise.toml"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -84,6 +85,22 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
+    },
+    {
+      description: "Kubernetes and Talos Group",
+      groupName: "Kubernetes and Talos",
+      matchDatasources: ["github-releases", "docker"],
+      matchPackageNames: [
+        "siderolabs/talos",
+        "kubernetes/kubernetes",
+        "ghcr.io/siderolabs/talosctl",
+        "ghcr.io/jfroy/tnu"
+      ],
+      matchFileNames: [".mise.toml"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumReleaseAge: "3 days"
     },
   ],
 }

--- a/.renovate/talosFactory.json5
+++ b/.renovate/talosFactory.json5
@@ -1,0 +1,29 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Talos Factory Schematic Images",
+      groupName: "Talos Factory",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "/factory.talos.dev/installer/",
+        "/ghcr.io/siderolabs/installer/"
+      ],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumReleaseAge: "3 days",
+      extractVersion: "^(?<version>v\\d+\\.\\d+\\.\\d+).*$"
+    },
+    {
+      description: "Override for Talos machine configs with static image references",
+      matchFileNames: ["talos/static-configs/**"],
+      matchPackageNames: [
+        "/factory.talos.dev/installer/",
+        "/ghcr.io/siderolabs/installer/"
+      ],
+      enabled: false,
+      prTitle: "chore(talos): update installer image in {{{depName}}} to {{{newVersion}}}"
+    }
+  ]
+}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -9,6 +9,7 @@
     "github>cpritchett/home-ops//.renovate/customManagers.json5",
     "github>cpritchett/home-ops//.renovate/grafanaDashboards.json5",
     "github>cpritchett/home-ops//.renovate/groups.json5",
+    "github>cpritchett/home-ops//.renovate/talosFactory.json5",
     "github>cpritchett/home-ops//.renovate/labels.json5",
     "github>cpritchett/home-ops//.renovate/semanticCommits.json5",
     ":automergeBranch",

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/ks.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/ks.yaml
@@ -39,7 +39,7 @@ spec:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
       KUBERNETES_VERSION: v1.33.4
       # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-      TALOS_VERSION: v1.10.6
+      TALOS_VERSION: v1.11.0-beta.2
   prune: true
   retryInterval: 2m
   sourceRef:


### PR DESCRIPTION
## Summary
- Add Kubernetes and Talos group for coordinated version updates
- Add talosFactory.json5 for Talos installer image management  
- Add custom managers for mise.toml version tracking
- Group flux2 tool with Flux Operator updates
- Upgrade Talos to v1.11.0-beta.2 and sync versions across files

## Test plan
- [ ] Verify Renovate can parse new configuration files
- [ ] Check that version updates group correctly in future PRs
- [ ] Confirm mise.toml versions stay synchronized with system upgrade controller

🤖 Generated with [Claude Code](https://claude.ai/code)