### PR TITLE
fix(mosquitto): add missing PVC and align storage configuration

### DIFF
--- a/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
           http:
             port: 1883
     persistence:
-      data:
+      config:
         existingClaim: "{{ .Release.Name }}"
       config-file:
         type: configMap

--- a/kubernetes/apps/default/mosquitto/app/kustomization.yaml
+++ b/kubernetes/apps/default/mosquitto/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./pvc.yaml
 configMapGenerator:
   - name: mosquitto-configmap
     files:

--- a/kubernetes/apps/default/mosquitto/app/pvc.yaml
+++ b/kubernetes/apps/default/mosquitto/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mosquitto
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/default/mosquitto/app/resources/mosquitto.conf
+++ b/kubernetes/apps/default/mosquitto/app/resources/mosquitto.conf
@@ -4,4 +4,4 @@ connection_messages false
 listener 1883
 per_listener_settings false
 persistence true
-persistence_location /data
+persistence_location /config


### PR DESCRIPTION
This pull request updates the Mosquitto deployment configuration to improve how persistent storage is managed. The changes shift the persistence location from `/data` to `/config`, introduce a dedicated PersistentVolumeClaim resource, and update references throughout the Kubernetes manifests to align with this new storage approach.

**Persistent storage improvements:**

* Added a new `PersistentVolumeClaim` resource in `pvc.yaml` to provide dedicated storage for Mosquitto, specifying a 1Gi volume using the `ceph-block` storage class.
* Updated `helmrelease.yaml` to reference the new `config` claim instead of the previous `data` claim for persistence, ensuring Mosquitto uses the correct volume.
* Changed the persistence location in `mosquitto.conf` from `/data` to `/config` to match the new volume mount path.

**Kubernetes manifest updates:**

* Modified `kustomization.yaml` to include the new `pvc.yaml` resource, ensuring the PersistentVolumeClaim is created when deploying Mosquitto.