### PR TITLE
fix(external-dns): align configurations with best practices

### DIFF
--- a/kubernetes/apps/networking/external-dns/cloudflare/rbac.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/rbac.yaml
@@ -10,7 +10,13 @@ metadata:
   name: external-dns-cloudflare
 rules:
   - apiGroups: [""]
-    resources: ["namespaces"]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "services"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes", "gateways"]

--- a/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -72,8 +72,8 @@ spec:
               tag: v0.18.0@sha256:f90738b35be265d50141d5c21e6f6049c3da7cd761682c40214117a2951b80bc # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             args:
               - --domain-filter=hypyr.space
-              # TODO: Re-evaluate --events flag and interval once cluster stabilizes - UniFi gateway currently unhappy with frequency
-              - --interval=5m
+              - --events
+              - --interval=1m
               - --log-format=text
               - --log-level=info
               - --policy=sync


### PR DESCRIPTION
This pull request updates RBAC permissions for the External DNS Cloudflare integration and adjusts the configuration for the External DNS UniFi deployment to improve event handling and synchronization intervals.

**RBAC permission enhancements (`external-dns-cloudflare`):**
* Expanded permissions to include `nodes` with `list` and `watch` verbs, allowing the service to monitor node changes.
* Added permissions for `namespaces`, `pods`, and `services` resources with `get`, `watch`, and `list` verbs, enabling broader resource visibility.
* Introduced access to `endpointslices` in the `discovery.k8s.io` API group, supporting more comprehensive endpoint discovery.

**Configuration changes (`external-dns-unifi`):**
* Enabled the `--events` flag and reduced the sync interval from 5 minutes to 1 minute, allowing for more frequent updates and improved responsiveness to cluster changes.