### PR TITLE
fix(media): improve health check timing for bazarr, overseerr, tautulli

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -35,10 +35,10 @@ spec:
                   httpGet:
                     path: /health
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 30
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness: *probes
             resources:
               requests:

--- a/kubernetes/apps/media/overseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/overseerr/app/helmrelease.yaml
@@ -36,10 +36,10 @@ spec:
                   httpGet:
                     path: /api/v1/status
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 30
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness: *probes
             resources:
               requests:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -35,10 +35,10 @@ spec:
                   httpGet:
                     path: /status
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 30
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness: *probes
             resources:
               requests:


### PR DESCRIPTION
Increases startup delays and timeouts for media services that need more time to initialize properly. Aligns with buroa/k8s-gitops patterns while providing more forgiving health check timing.

Changes:
- initialDelaySeconds: 0 → 30 (give apps time to start)
- timeoutSeconds: 1 → 5 (more generous timeout)
- failureThreshold: 3 → 5 (more attempts before restart)

Fixes CrashLoopBackOff issues where apps restart before fully initialized. Maintains buroa's proven endpoint patterns (/health, /api/v1/status, /status).

🤖 Generated with [Claude Code](https://claude.ai/code)