### PR TITLE
fix(media): improve health check timing and fix tautulli port 

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -35,10 +35,10 @@ spec:
                   httpGet:
                     path: /health
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 30
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness: *probes
             resources:
               requests:

--- a/kubernetes/apps/media/overseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/overseerr/app/helmrelease.yaml
@@ -36,10 +36,10 @@ spec:
                   httpGet:
                     path: /api/v1/status
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 30
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness: *probes
             resources:
               requests:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
               repository: ghcr.io/home-operations/tautulli
               tag: 2.15.3@sha256:3e0eaca8c082ebe121a0ae9125bea1b4e2d177fca34ac8df4ec14a28e62f63a4 # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             env:
-              TAUTULLI__PORT: &port 80
+              TAUTULLI_HTTP_PORT: &port 80
               TZ: America/Chicago
             probes:
               liveness: &probes
@@ -35,10 +35,10 @@ spec:
                   httpGet:
                     path: /status
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 30
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness: *probes
             resources:
               requests:


### PR DESCRIPTION
This pull request updates the Kubernetes HelmRelease configurations for the Bazarr, Overseerr, and Tautulli media apps to improve container startup reliability and readiness/liveness probe consistency. The main focus is on standardizing probe settings and correcting environment variable naming.

**Probe configuration improvements:**

* Increased `initialDelaySeconds` from 0 to 30 for liveness probes in Bazarr, Overseerr, and Tautulli, allowing more time for containers to start before health checks begin. [[1]](diffhunk://#diff-c72c7c97967aa5537ce621e9c23643b4d915498be7386ac64b0355dfbaf84fc2L38-R41) [[2]](diffhunk://#diff-f1fd6b1215120654a47d2f3bc926e4690341e575c8d55ed99d25f3cc96b54bbdL39-R42) [[3]](diffhunk://#diff-6ff8bef742d75a144a222497ee65b7026410a254acbc439dd50948e6481cf76bL38-R41)
* Increased `timeoutSeconds` from 1 to 5 and `failureThreshold` from 3 to 5 in liveness probes for all three apps, making health checks more robust against transient failures. [[1]](diffhunk://#diff-c72c7c97967aa5537ce621e9c23643b4d915498be7386ac64b0355dfbaf84fc2L38-R41) [[2]](diffhunk://#diff-f1fd6b1215120654a47d2f3bc926e4690341e575c8d55ed99d25f3cc96b54bbdL39-R42) [[3]](diffhunk://#diff-6ff8bef742d75a144a222497ee65b7026410a254acbc439dd50948e6481cf76bL38-R41)

**Environment variable correction:**

* Renamed Tautulli's environment variable from `TAUTULLI__PORT` to `TAUTULLI_HTTP_PORT` to match expected configuration.