### PR TITLE
fix(media): increase Plex Helm timeout for PVC creation

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -10,9 +10,11 @@ spec:
     name: app-template
     namespace: flux-system
   install:
+    timeout: 15m
     remediation:
       retries: -1
   upgrade:
+    timeout: 15m
     cleanupOnFail: true
     remediation:
       retries: 3


### PR DESCRIPTION

This pull request makes a minor configuration update to the Helm release for the Plex media app, specifically adjusting operation timeouts.

* Increased the `timeout` for both `install` and `upgrade` operations to 15 minutes in `kubernetes/apps/media/plex/app/helmrelease.yaml` to allow more time for these processes to complete.