### PR TITLE
fix(cloudflared): use bitnami/kubectl image for init container

### DIFF
--- a/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           generate-config:
             image:
               repository: ghcr.io/home-operations/kubectl
-              tag: 1.31.4@sha256:8da088399f96c65ab0e2c87edc9a5f5e99c699f3f1a1f8e1e0efe659e2a91f723
+              tag: 1.31.4
             command:
               - /scripts/generate-config.sh
             securityContext:

--- a/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
         initContainers:
           generate-config:
             image:
-              repository: ghcr.io/home-operations/kubectl
+              repository: docker.io/bitnami/kubectl
               tag: 1.31.4
             command:
               - /scripts/generate-config.sh


### PR DESCRIPTION
- Replace non-existent ghcr.io/home-operations/kubectl with bitnami/kubectl
- Fixes ImagePullBackOff error in init container