### PR TITLE
fix(cilium): resolve OCIRepository validation issue

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -21,13 +21,6 @@ spec:
   chartRef:
     kind: OCIRepository
     name: cilium
-  chart:
-    spec:
-      chart: cilium
-      sourceRef:
-        kind: OCIRepository
-        name: cilium
-      version: 1.18.1
   install:
     remediation:
       retries: -1


### PR DESCRIPTION
## Summary
- Fixed Cilium HelmRelease OCIRepository configuration validation failure
- Removed redundant chart spec that conflicted with chartRef usage

## Root Cause
The HelmRelease had both `chartRef` and `chart.spec` defined, but Flux requires only one approach. When both are present, validation fails on the `chart.spec.sourceRef.kind: OCIRepository` path since HelmRelease CRD only supports `["HelmRepository", "GitRepository", "Bucket"]` for that field.

## Solution
- Removed the redundant `chart.spec` section
- Kept only `chartRef` which is the correct way to reference OCIRepository
- This aligns with official Flux documentation for OCIRepository usage

## Test Plan
- [x] Fixed validation error preventing Cilium kustomization reconciliation
- [ ] Verify Cilium HelmRelease can reconcile successfully
- [ ] Confirm Cilium networking remains functional

🤖 Generated with [Claude Code](https://claude.ai/code)