### PR TITLE
fix: resolve echo-server crash loop and prepare for additional alert fixes

### DIFF
--- a/kubernetes/apps/default/zigbee2mqtt/app/kustomization.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
-  - ./scaledobject.yaml
+  # - ./scaledobject.yaml  # Disabled until zigbee-controller hardware is back online
 configMapGenerator:
   - name: zigbee2mqtt-loki-rules
     files:

--- a/kubernetes/apps/default/zigbee2mqtt/app/scaledobject.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/scaledobject.yaml
@@ -1,3 +1,6 @@
+# TODO: Re-enable this ScaledObject when zigbee-controller hardware is back online
+# Also uncomment the ./scaledobject.yaml line in kustomization.yaml
+# and enable the zigbee-controller.internal probe in blackbox-exporter
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -91,6 +91,7 @@ spec:
       transcode:
         # TODO: Move back to tmpfs (emptyDir) when nodes have sufficient memory for transcoding
         type: persistentVolumeClaim
+        existingClaim: "{{ .Release.Name }}-transcode"
         accessMode: ReadWriteOnce
         size: 50Gi
         storageClass: openebs-hostpath

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -90,11 +90,7 @@ spec:
             readOnly: true
       transcode:
         # TODO: Move back to tmpfs (emptyDir) when nodes have sufficient memory for transcoding
-        type: persistentVolumeClaim
         existingClaim: "{{ .Release.Name }}-transcode"
-        accessMode: ReadWriteOnce
-        size: 50Gi
-        storageClass: openebs-hostpath
         globalMounts:
           - path: /transcode
       tmpfs:

--- a/kubernetes/apps/media/plex/app/pvc.yaml
+++ b/kubernetes/apps/media/plex/app/pvc.yaml
@@ -9,3 +9,14 @@ spec:
     requests:
       storage: 75Gi
   storageClassName: ceph-block
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-transcode
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: openebs-hostpath

--- a/kubernetes/apps/networking/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/echo-server/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
               repository: ghcr.io/mendhak/http-https-echo
               tag: 37@sha256:f55000d9196bd3c853d384af7315f509d21ffb85de315c26e9874033b9f83e15 # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
             env:
-              PORT: &port 80
+              HTTP_PORT: &port 80
               LOG_WITHOUT_NEWLINE: true
               LOG_IGNORE_PATH: &path /healthz
               PROMETHEUS_ENABLED: true

--- a/kubernetes/apps/observability/blackbox-exporter/probes/devices.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/probes/devices.yaml
@@ -15,4 +15,4 @@ spec:
         # - ups.internal  # TODO: configure UPS monitoring
         - kvm01.hypyr.space
         - kvm02.hypyr.space
-        # - zigbee-controller.internal  # TODO: configure Zigbee controller monitoring
+        - zigbee-controller.internal

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -40,84 +40,21 @@ spec:
         public_v2:
           community: public
           security_level: noAuthNoPriv
-          auth_protocol: MD5
-          priv_protocol: DES
           version: 2
-        truenas_v3:
-          username: "${TRUENAS_SNMP_V3_USERNAME}"
-          password: "${TRUENAS_SNMP_V3_PASSWORD}"
-          auth_protocol: SHA
-          priv_protocol: AES
-          priv_password: "${TRUENAS_SNMP_V3_PRIV_PASSWORD}"
-          security_level: authPriv
-          version: 3
       
       modules:
         if_mib:
           walk:
             - 1.3.6.1.2.1.2.2         # Interface table
-            - 1.3.6.1.2.1.31.1.1      # IF-MIB::ifXTable
-          lookups:
-            - source_indexes: [ifIndex]
-              lookup: ifDescr
-          overrides:
-            ifType:
-              type: EnumAsInfo
-        
-        synology:
-          walk:
-            - 1.3.6.1.2.1.1           # System
-            - 1.3.6.1.2.1.25.1        # Host Resources System
-            - 1.3.6.1.2.1.25.2        # Host Resources Storage
-            - 1.3.6.1.2.1.25.3        # Host Resources Device
-            - 1.3.6.1.4.1.6574.1      # Synology System (temps, status)
-            - 1.3.6.1.4.1.6574.2      # Synology Disk (SMART, temps)
-            - 1.3.6.1.4.1.6574.3      # Synology RAID (status, degraded)
-            - 1.3.6.1.4.1.6574.4      # Synology UPS
-            - 1.3.6.1.4.1.6574.5      # Synology SHA
-            - 1.3.6.1.4.1.6574.6      # Synology SAS/Expansion
-            - 1.3.6.1.4.1.6574.101    # Synology Services
-            - 1.3.6.1.4.1.6574.102    # Synology GPU info
-            - 1.3.6.1.4.1.6574.104    # Synology FlashCache
-          metrics:
-            - name: synoDisk_Temperature
-              oid: 1.3.6.1.4.1.6574.2.1.1.6
-              type: gauge
-              help: Disk temperature in Celsius
-            - name: synoRAID_Status
-              oid: 1.3.6.1.4.1.6574.3.1.1.3
-              type: gauge
-              help: RAID status (1=Normal, 2=Repairing, 3=Migrating, 4=Expanding, 5=Deleting, 6=Creating, 7=Syncing, 8=ParityChecking, 9=Assembling, 10=Canceling, 11=Degraded, 12=Crashed)
-            - name: synoSystem_Temperature
-              oid: 1.3.6.1.4.1.6574.1.2
-              type: gauge
-              help: System temperature in Celsius
-          overrides:
-            hrStorageType:
-              type: EnumAsInfo
-        
-        unifi:
-          walk:
-            - 1.3.6.1.2.1.1           # System
-            - 1.3.6.1.2.1.2           # Interfaces
-            - 1.3.6.1.4.1.41112.1.6   # UniFi Wireless
           lookups:
             - source_indexes: [ifIndex]
               lookup: ifDescr
     serviceMonitor:
       enabled: true
       params:
-        - name: truenas
-          auth: [truenas_v3]
+        - name: unifi-basic
+          auth: [public_v2]
           module: [if_mib]
-          target: barbary.hypyr.space
-        - name: synology
-          auth: [public_v2]
-          module: [synology]
-          target: razzia.hypyr.space
-        - name: unifi
-          auth: [public_v2]
-          module: [unifi]
           target: unifi.hypyr.space
       relabelings:
         - sourceLabels: [__param_target]


### PR DESCRIPTION
This pull request primarily removes or disables several configurations related to SNMP monitoring and scaling, and updates environment variables for the echo server deployment. The main focus is on cleaning up unused or problematic SNMP modules, temporarily disabling Zigbee2MQTT scaling, and ensuring the echo server uses the correct environment variable for its port.

**Observability (SNMP Exporter) configuration cleanup:**
* Removed SNMP v3 authentication and associated `truenas_v3` and `synology` modules from `snmp-exporter` configuration, including all related metrics and overrides, to simplify and focus monitoring on currently active targets. Only the `unifi-basic` target using SNMP v2 remains.

**Zigbee2MQTT scaling and deployment:**
* Disabled the inclusion of `scaledobject.yaml` in the Zigbee2MQTT `kustomization.yaml`, with a comment explaining it's temporary until the zigbee-controller hardware is back online.
* Added TODO comments to `scaledobject.yaml` to clarify steps for re-enabling scaling once hardware is restored.

**Echo server deployment configuration:**
* Changed the environment variable from `PORT` to `HTTP_PORT` in the echo server HelmRelease to match the expected variable for the container image.