### PR TITLE
fix(plex): remove init container causing security context conflict

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -21,21 +21,6 @@ spec:
   values:
     controllers:
       plex:
-        initContainers:
-          init-config:
-            image:
-              repository: busybox
-              tag: 1.37.0
-            command:
-              - /bin/sh
-              - -c
-              - |
-                chown -R 568:568 /config
-                find /config -type d -exec chmod 755 {} \;
-                find /config -type f -exec chmod 644 {} \;
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
         containers:
           app:
             image:


### PR DESCRIPTION
This pull request removes the `init-config` initContainer configuration from the Plex Helm release specification. This change simplifies the deployment configuration by eliminating the container that was previously used to set ownership and permissions on the `/config` directory.

Configuration cleanup:

* Removed the `init-config` initContainer, including its image, command to set file permissions, and security context, from the `plex` controller in `kubernetes/apps/media/plex/app/helmrelease.yaml`.