### PR TITLE
fix(k8s): comprehensive error handling improvements for nuke-app task

### DIFF
--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -309,9 +309,14 @@ tasks:
           kubectl delete "$resource_type" -n "$namespace" -l "$label_selector" --ignore-not-found=true || echo "⚠️  Failed to delete labeled $resource_type"
           
           echo "Deleting additional $resource_type matching '$app'..."
-          local resources
-          resources=$(kubectl get "$resource_type" -n "$namespace" --no-headers 2>/dev/null | grep "$app" | awk '{print $1}' || true)
-          if [[ -n "$resources" ]]; then
+          # Temporarily disable strict error checking for this section
+          set +e
+          local resources=""
+          resources=$(kubectl get "$resource_type" -n "$namespace" --no-headers 2>/dev/null | grep "$app" | awk '{print $1}' 2>/dev/null)
+          local grep_exit_code=$?
+          set -e
+          
+          if [[ -n "$resources" && "$grep_exit_code" -eq 0 ]]; then
             echo "$resources" | xargs -r kubectl delete "$resource_type" -n "$namespace" || echo "⚠️  Failed to delete some $resource_type"
           else
             echo "No additional $resource_type found matching '$app'"

--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -326,7 +326,9 @@ tasks:
           set -e
           
           if [[ -n "$resources" ]]; then
-            echo "$resources" | xargs -r kubectl delete "$resource_type" -n "$namespace" || echo "⚠️  Failed to delete some $resource_type"
+            while IFS= read -r res_name; do
+              kubectl delete "$resource_type" -n "$namespace" "$res_name" || echo "⚠️  Failed to delete $resource_type: $res_name"
+            done <<< "$resources"
           else
             echo "No additional $resource_type found matching '$app'"
           fi

--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -296,6 +296,28 @@ tasks:
       vars: [APP, NAMESPACE]
     cmds:
       - |
+        set -euo pipefail
+
+        # Function for safer command execution with error handling
+        safe_delete() {
+          local resource_type="$1"
+          local namespace="$2"
+          local app="$3"
+          local label_selector="app.kubernetes.io/name=$app"
+          
+          echo "Deleting $resource_type with label $label_selector..."
+          kubectl delete "$resource_type" -n "$namespace" -l "$label_selector" --ignore-not-found=true || echo "⚠️  Failed to delete labeled $resource_type"
+          
+          echo "Deleting additional $resource_type matching '$app'..."
+          local resources
+          resources=$(kubectl get "$resource_type" -n "$namespace" --no-headers 2>/dev/null | grep "$app" | awk '{print $1}' || true)
+          if [[ -n "$resources" ]]; then
+            echo "$resources" | xargs -r kubectl delete "$resource_type" -n "$namespace" || echo "⚠️  Failed to delete some $resource_type"
+          else
+            echo "No additional $resource_type found matching '$app'"
+          fi
+        }
+
         echo "🚨 NUCLEAR APP DESTRUCTION: {{.APP}} in namespace {{.NAMESPACE}}"
         echo "This will completely destroy and rebuild the application!"
         read -p "Type 'NUKE {{.APP}}' to confirm: " confirm
@@ -321,37 +343,45 @@ tasks:
         fi
 
         echo "🔑 Step 3: Deleting app-related secrets..."
-        kubectl delete secrets -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --ignore-not-found=true
-        kubectl get secrets -n {{.NAMESPACE}} --no-headers | grep {{.APP}} | awk '{print $1}' | xargs -r kubectl delete secret -n {{.NAMESPACE}}
+        safe_delete "secrets" "{{.NAMESPACE}}" "{{.APP}}"
         echo "✅ App secrets deleted"
 
         echo "📋 Step 4: Deleting app-related configmaps..."
-        kubectl delete configmaps -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --ignore-not-found=true
-        kubectl get configmaps -n {{.NAMESPACE}} --no-headers | grep {{.APP}} | awk '{print $1}' | xargs -r kubectl delete configmap -n {{.NAMESPACE}}
+        safe_delete "configmaps" "{{.NAMESPACE}}" "{{.APP}}"
         echo "✅ App configmaps deleted"
 
-        echo "💾 Step 5: Deleting app-related PVCs..."
-        kubectl delete pvc -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --ignore-not-found=true
-        kubectl get pvc -n {{.NAMESPACE}} | grep {{.APP}} | awk '{print $1}' | xargs -r kubectl delete pvc -n {{.NAMESPACE}}
-        echo "✅ App PVCs deleted"
-
-        echo "☠️  Step 6: Force deleting all app resources..."
-        kubectl delete pods -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --grace-period=0 --force --ignore-not-found=true
-        kubectl delete replicasets -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --grace-period=0 --force --ignore-not-found=true
-        kubectl delete deployments -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --grace-period=0 --force --ignore-not-found=true
+        echo "☠️  Step 5: Force deleting all app resources..."
+        echo "Deleting pods..."
+        kubectl delete pods -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --grace-period=0 --force --ignore-not-found=true || echo "⚠️  Failed to delete some pods"
+        echo "Deleting replicasets..."
+        kubectl delete replicasets -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --grace-period=0 --force --ignore-not-found=true || echo "⚠️  Failed to delete some replicasets"
+        echo "Deleting deployments..."
+        kubectl delete deployments -n {{.NAMESPACE}} -l app.kubernetes.io/name={{.APP}} --grace-period=0 --force --ignore-not-found=true || echo "⚠️  Failed to delete some deployments"
+        echo "Deleting HPAs..."
+        safe_delete "hpa" "{{.NAMESPACE}}" "{{.APP}}"
         echo "✅ All app resources deleted"
+
+        echo "⏳ Waiting for resource cleanup..."
+        sleep 10
+
+        echo "💾 Step 6: Deleting app-related PVCs..."
+        safe_delete "pvc" "{{.NAMESPACE}}" "{{.APP}}"
+        echo "✅ App PVCs deleted"
 
         echo "⏳ Step 7: Waiting for cleanup..."
         sleep 5
 
         echo "🔄 Step 8: Resuming Flux HelmRelease for clean rebuild..."
         if kubectl get helmrelease {{.APP}} -n {{.NAMESPACE}} >/dev/null 2>&1; then
-          flux resume helmrelease {{.APP}} -n {{.NAMESPACE}}
-          flux reconcile helmrelease {{.APP}} -n {{.NAMESPACE}}
+          echo "Resuming HelmRelease..."
+          flux resume helmrelease {{.APP}} -n {{.NAMESPACE}} || echo "⚠️  Failed to resume HelmRelease"
+          echo "Forcing reconciliation..."
+          flux reconcile helmrelease {{.APP}} -n {{.NAMESPACE}} || echo "⚠️  Failed to reconcile HelmRelease"
           echo "✅ Flux reconciliation resumed"
         else
           echo "⚠️  No HelmRelease to resume - check Git configuration"
         fi
 
         echo "💥 App {{.APP}} has been completely nuked and rebuild initiated"
-        echo "Monitor with: kubectl get pods -n {{.NAMESPACE}} -w"
+        echo "📋 Monitor with: kubectl get pods -n {{.NAMESPACE}} -w"
+        echo "📋 Check HelmRelease: flux get helmreleases -n {{.NAMESPACE}} {{.APP}}"

--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -316,7 +316,9 @@ tasks:
           local grep_exit_code=$?
           set -e
           
-          if [[ -n "$resources" && "$grep_exit_code" -eq 0 ]]; then
+          set -e
+          
+          if [[ -n "$resources" ]]; then
             echo "$resources" | xargs -r kubectl delete "$resource_type" -n "$namespace" || echo "⚠️  Failed to delete some $resource_type"
           else
             echo "No additional $resource_type found matching '$app'"

--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -313,7 +313,14 @@ tasks:
           set +e
           local resources=""
           resources=$(kubectl get "$resource_type" -n "$namespace" --no-headers 2>/dev/null | grep "$app" | awk '{print $1}' 2>/dev/null)
+          local raw_output
+          raw_output=$(kubectl get "$resource_type" -n "$namespace" --no-headers 2>/dev/null | grep "$app" 2>/dev/null)
           local grep_exit_code=$?
+          if [[ "$grep_exit_code" -eq 0 ]]; then
+            resources=$(echo "$raw_output" | awk '{print $1}' 2>/dev/null)
+          else
+            resources=""
+          fi
           set -e
           
           set -e


### PR DESCRIPTION
## Summary
Implements robust error handling for the `k8s:nuke-app` task to eliminate exit status 1 failures and make the task more reliable.

## Problem
The nuke-app task was failing with `exit status 1` at various steps, particularly when:
- `grep` found no matching resources (exit code 1)
- Pipelines with `set -o pipefail` treated grep failures as task failures
- Strict error checking with `set -euo pipefail` exited on unset variables
- Resource deletion order caused PVC deletion failures (pods still using them)

## Solution
### 1. **Comprehensive Error Handling Framework**
- Added `set -euo pipefail` for strict error detection
- Created `safe_delete()` function with robust error handling
- Temporarily disables strict checking around operations that can legitimately fail
- Proper variable initialization and error code checking

### 2. **Safe Resource Deletion Function**
```bash
safe_delete() {
  # Delete by label selector first
  kubectl delete $resource_type -l app.kubernetes.io/name=$app --ignore-not-found=true
  
  # Then find and delete by name pattern with safe error handling
  set +e  # Temporarily allow failures
  resources=$(kubectl get $resource_type | grep $app | awk '{print $1}')
  set -e  # Re-enable strict checking
  
  # Only delete if resources found and grep succeeded
  if [[ -n "$resources" && $? -eq 0 ]]; then
    echo "$resources" | xargs -r kubectl delete $resource_type
  fi
}
```

### 3. **Improved Resource Deletion Sequence**
- **Step 5**: Delete pods/deployments/HPAs FIRST (releases PVC locks)
- **Step 6**: Delete PVCs AFTER (now safe to delete)
- Added HPA deletion to prevent resource recreation loops

### 4. **Individual Error Handling**
- Each deletion step continues even if individual commands fail
- Clear progress reporting with ⚠️ warnings for failures
- Helpful monitoring commands provided at completion

## Testing
- [x] Tested with resources that exist and don't exist
- [x] Verified task completes successfully in all scenarios
- [x] Confirmed no exit status 1 failures on empty grep results
- [x] Validated proper resource deletion sequence
- [x] Successfully nuked and rebuilt Plex application

## Impact
- ✅ Task now completes successfully even when some resources don't exist
- ✅ Provides clear feedback about what succeeded/failed
- ✅ No longer exits early due to expected conditions (no resources found)
- ✅ Handles all edge cases gracefully
- ✅ Much more reliable for GitOps application rebuilds

## Files Changed
- `.taskfiles/kubernetes/Taskfile.yaml`: Complete rewrite of nuke-app task with robust error handling

The `task k8s:nuke-app` command is now a reliable tool for completely destroying and rebuilding applications.