### PR TITLE
fix(plex): plex tweaks

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -10,11 +10,9 @@ spec:
     name: app-template
     namespace: flux-system
   install:
-    timeout: 15m
     remediation:
       retries: -1
   upgrade:
-    timeout: 15m
     cleanupOnFail: true
     remediation:
       retries: 3
@@ -73,7 +71,7 @@ spec:
         runAsGroup: 568
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch
-        supplementalGroups: [1702, 44, 65536]
+        supplementalGroups: [1702, 65536]
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"


### PR DESCRIPTION
This pull request makes minor adjustments to the `kubernetes/apps/media/plex/app/helmrelease.yaml` file, focusing on Helm release configuration and Kubernetes security context.

Helm release configuration:

* Removed the `timeout: 15m` setting from both the `install` and `upgrade` sections under `spec`, streamlining the deployment configuration.

Kubernetes security context:

* Updated the `supplementalGroups` list by removing group `44`, leaving only `1702` and `65536`, which may affect file system permissions for the Plex container.