### PR TITLE
fix(plex): change fsGroupChangePolicy to Always for volume ownership

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
         runAsUser: 568
         runAsGroup: 568
         fsGroup: 568
-        fsGroupChangePolicy: OnRootMismatch
+        fsGroupChangePolicy: Always
         supplementalGroups: [1702, 65536]
     persistence:
       config:


### PR DESCRIPTION
## Summary

Fixes Plex volume ownership issues by changing `fsGroupChangePolicy` from `OnRootMismatch` to `Always`.

## Problem

Plex volumes had mixed ownership (`root:568`, `root:root`) causing permission issues. The `OnRootMismatch` policy only fixes `root:root` → `568:568`, not `root:568` → `568:568`.

## Solution

- Change `fsGroupChangePolicy: Always` to fix any ownership → `568:568`
- Kubernetes-native solution following community patterns
- No init containers or complex workarounds needed
- Maintains persistent transcode volume on local storage

## Test Plan

- [x] Cache PVC recreated (was corrupted)
- [x] Deployment updated via Flux
- [ ] Verify proper ownership after pod restart
- [ ] Confirm bootstrap works on clean volumes

🤖 Generated with [Claude Code](https://claude.ai/code)