### PR TITLE
fix(rook-ceph): implement proper node placement constraints

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -85,18 +85,20 @@ spec:
         provider: host
         connections:
           requireMsgr2: true
+      placement:
+        osd:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: ceph-storage
+                      operator: In
+                      values:
+                        - enabled
       storage:
         useAllNodes: true
         useAllDevices: false
         deviceFilter: "^nvme[0-9]+n[0-9]+$"
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: ceph-storage
-                    operator: In
-                    values:
-                      - enabled
         config:
           osdsPerDevice: "1"
     cephBlockPools:


### PR DESCRIPTION
## Summary
- Fix Rook Ceph node selection configuration by moving nodeAffinity from storage section to placement.osd section
- Maintain useAllNodes: true for node discovery while using placement constraints for OSD scheduling
- Follows documented Rook pattern for label-based node exclusion

## Changes
- Move nodeAffinity configuration from cephClusterSpec.storage to cephClusterSpec.placement.osd
- Keep useAllNodes: true to enable automatic node discovery
- Use ceph-storage=enabled label requirement for OSD placement

## Test Plan
- [x] Verify Ceph cluster is healthy with 3 OSDs
- [x] Confirm storage classes are available
- [ ] Test node exclusion when home03 is re-added with ceph-storage!=enabled

This follows the proven pattern of using labels for exclusion rather than static node lists, similar to using noindex tags instead of robots.txt disallow rules.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>