### PR TITLE
feat(sonarr): migrate from PostgreSQL to SQLite

### DIFF
--- a/kubernetes/apps/media/sonarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sonarr/app/externalsecret.yaml
@@ -13,19 +13,6 @@ spec:
     template:
       data:
         SONARR__AUTH__APIKEY: "{{ .SONARR_API_KEY }}"
-        SONARR__POSTGRES__HOST: &dbHost postgres-rw.databases.svc.cluster.local
-        SONARR__POSTGRES__PORT: "5432"
-        SONARR__POSTGRES__USER: &dbUser "{{ .SONARR_POSTGRES_USER }}"
-        SONARR__POSTGRES__PASSWORD: &dbPass "{{ .SONARR_POSTGRES_PASS }}"
-        SONARR__POSTGRES__MAINDB: sonarr_main
-        SONARR__POSTGRES__LOGDB: sonarr_log
-        INIT_POSTGRES_DBNAME: sonarr_main sonarr_log
-        INIT_POSTGRES_HOST: *dbHost
-        INIT_POSTGRES_USER: *dbUser
-        INIT_POSTGRES_PASS: *dbPass
-        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
   dataFrom:
-    - extract:
-        key: cloudnative-pg
     - extract:
         key: sonarr

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -21,14 +21,6 @@ spec:
       sonarr:
         annotations:
           reloader.stakater.com/auto: "true"
-        initContainers:
-          init-db:
-            image:
-              repository: ghcr.io/home-operations/postgres-init
-              tag: 17
-            envFrom: &envFrom
-              - secretRef:
-                  name: "{{ .Release.Name }}-secret"
         containers:
           app:
             image:
@@ -43,7 +35,9 @@ spec:
               SONARR__SERVER__PORT: &port 80
               SONARR__UPDATE__BRANCH: develop
               TZ: America/Chicago
-            envFrom: *envFrom
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
             probes:
               liveness: &probes
                 enabled: true
@@ -78,6 +72,10 @@ spec:
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"
+      config-cache:
+        existingClaim: "{{ .Release.Name }}-cache"
+        globalMounts:
+          - path: /config/MediaCover
       media:
         type: nfs
         server: ${NFS_SERVER}

--- a/kubernetes/apps/media/sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr/app/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/media/sonarr/app/pvc.yaml
+++ b/kubernetes/apps/media/sonarr/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr-cache
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 15Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -12,8 +12,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: cloudnative-pg-cluster
-      namespace: databases
     - name: onepassword-store
       namespace: external-secrets
     - name: rook-ceph-cluster


### PR DESCRIPTION
## Summary
Migrates Sonarr from PostgreSQL to SQLite database backend.

## Changes
- ✅ Remove postgres-init init container and database dependencies
- ✅ Add MediaCover cache PVC for performance optimization  
- ✅ Simplify external secret to API key only
- ✅ Remove cloudnative-pg-cluster dependency from kustomization

## Benefits
- Eliminates database clustering complexity
- Reduces operational overhead
- SQLite provides adequate performance for homelab workloads
- MediaCover caching improves UI responsiveness

## Test Plan
- [ ] Verify Sonarr pod starts successfully
- [ ] Confirm SQLite database creation in /config
- [ ] Test MediaCover cache functionality
- [ ] Validate API key authentication

🤖 Generated with [Claude Code](https://claude.ai/code)