### PR TITLE
feat(prowlarr): migrate from PostgreSQL to SQLite

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
@@ -13,19 +13,6 @@ spec:
     template:
       data:
         PROWLARR__AUTH__APIKEY: "{{ .PROWLARR_API_KEY }}"
-        PROWLARR__POSTGRES__HOST: &dbHost postgres-rw.databases.svc.cluster.local
-        PROWLARR__POSTGRES__PORT: "5432"
-        PROWLARR__POSTGRES__USER: &dbUser "{{ .PROWLARR_POSTGRES_USER }}"
-        PROWLARR__POSTGRES__PASSWORD: &dbPass "{{ .PROWLARR_POSTGRES_PASS }}"
-        PROWLARR__POSTGRES__MAINDB: prowlarr_main
-        PROWLARR__POSTGRES__LOGDB: prowlarr_log
-        INIT_POSTGRES_DBNAME: prowlarr_main prowlarr_log
-        INIT_POSTGRES_HOST: *dbHost
-        INIT_POSTGRES_USER: *dbUser
-        INIT_POSTGRES_PASS: *dbPass
-        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
   dataFrom:
-    - extract:
-        key: cloudnative-pg
     - extract:
         key: prowlarr

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -21,14 +21,6 @@ spec:
       prowlarr:
         annotations:
           reloader.stakater.com/auto: "true"
-        initContainers:
-          init-db:
-            image:
-              repository: ghcr.io/home-operations/postgres-init
-              tag: 17
-            envFrom: &envFrom
-              - secretRef:
-                  name: "{{ .Release.Name }}-secret"
         containers:
           app:
             image:
@@ -43,7 +35,9 @@ spec:
               PROWLARR__SERVER__PORT: &port 80
               PROWLARR__UPDATE__BRANCH: develop
               TZ: America/Chicago
-            envFrom: *envFrom
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
               PROWLARR__SERVER__PORT: &port 80
               PROWLARR__UPDATE__BRANCH: develop
               TZ: America/Chicago
-            envFrom:
+            envFrom: &envFrom
               - secretRef:
                   name: "{{ .Release.Name }}-secret"
             probes:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -11,8 +11,6 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
-    - name: cloudnative-pg-cluster
-      namespace: databases
     - name: onepassword-store
       namespace: external-secrets
     - name: volsync


### PR DESCRIPTION
## Summary
Migrates Prowlarr from PostgreSQL to SQLite database backend.

## Changes
- ✅ Remove postgres-init init container and database dependencies
- ✅ Simplify external secret to API key only
- ✅ Remove cloudnative-pg-cluster dependency from kustomization
- ✅ No cache volume needed (indexer management doesn't use MediaCover)

## Benefits
- Eliminates database clustering complexity
- Reduces operational overhead
- SQLite provides adequate performance for indexer management
- Simpler configuration without cache requirements

## Test Plan
- [ ] Verify Prowlarr pod starts successfully
- [ ] Confirm SQLite database creation in /config
- [ ] Test indexer management functionality
- [ ] Validate API key authentication

🤖 Generated with [Claude Code](https://claude.ai/code)