### PR TITLE
feat(gatus): migrate from PostgreSQL to SQLite

### DIFF
--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -10,15 +10,6 @@ spec:
   target:
     name: gatus-secret
     creationPolicy: Owner
-    template:
-      data:
-        INIT_POSTGRES_DBNAME: gatus
-        INIT_POSTGRES_HOST: postgres-rw.databases.svc.cluster.local
-        INIT_POSTGRES_USER: "{{ .GATUS_POSTGRES_USER }}"
-        INIT_POSTGRES_PASS: "{{ .GATUS_POSTGRES_PASS }}"
-        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
   dataFrom:
-    - extract:
-        key: cloudnative-pg
     - extract:
         key: gatus

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -22,15 +22,7 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
-          init-db:
-            image:
-              repository: ghcr.io/home-operations/postgres-init
-              tag: 17
-            envFrom: &envFrom
-              - secretRef:
-                  name: "{{ .Release.Name }}-secret"
           init-config:
-            dependsOn: init-db
             image:
               repository: ghcr.io/home-operations/k8s-sidecar
               tag: 1.30.9@sha256:74d65c3def9276b24b5bfe41f8efb773174e7a1ecf3c9b5a31bd02cfdee232c9 # trunk-ignore(checkov/CKV_SECRET_6): legitimate container image SHA
@@ -57,7 +49,6 @@ spec:
               GATUS_CONFIG_PATH: /config
               GATUS_DELAY_START_SECONDS: 5
               TZ: America/Chicago
-            envFrom: *envFrom
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -32,11 +32,6 @@ endpoints:
 
 metrics: true
 
-storage:
-  type: postgres
-  path: postgres://${INIT_POSTGRES_USER}:${INIT_POSTGRES_PASS}@${INIT_POSTGRES_HOST}:5432/${INIT_POSTGRES_DBNAME}?sslmode=disable
-  caching: true
-
 ui:
   title: Status | Gatus
   header: Status

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -11,8 +11,6 @@ spec:
   components:
     - ../../../../components/gatus
   dependsOn:
-    - name: cloudnative-pg-cluster
-      namespace: databases
     - name: onepassword-store
       namespace: external-secrets
   interval: 1h


### PR DESCRIPTION
## Summary
- Remove postgres storage config from config.yaml (defaults to SQLite)
- Simplify external secret to only include gatus key  
- Remove cloudnative-pg dependency from kustomization
- Eliminates postgres connection complexity

Part of CloudNativePG removal initiative - migrating all applications to SQLite.