### PR TITLE
fix(kubewall): correct health probe configuration and network binding

### DIFF
--- a/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
@@ -26,19 +26,19 @@ spec:
               tag: 0.0.12
             args:
               - --no-open-browser
-              - --port=8443
+              - --listen=0.0.0.0:8443
             probes:
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
+                    path: /
                     port: &port 8443
-                    scheme: HTTPS
-                  initialDelaySeconds: 0
+                    scheme: HTTP
+                  initialDelaySeconds: 10
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
             resources:


### PR DESCRIPTION
## Summary
Fixes Kubewall pod CrashLoopBackOff caused by misconfigured health probes

## Changes
- **Network binding**: Change `--port=8443` to `--listen=0.0.0.0:8443` to bind all interfaces instead of localhost only
- **Health probe path**: Update from `/healthz` to `/` (Kubewall uses root endpoint)  
- **Protocol**: Switch from HTTPS to HTTP (no TLS certificates configured)
- **Probe timing**: Increase timeouts for reliability (initialDelay: 10s, timeout: 5s)

## Problem
Pod was in CrashLoopBackOff with health probes failing:
```
Readiness probe failed: Get "https://10.244.3.247:8443/healthz": dial tcp 10.244.3.247:8443: connect: connection refused
```

App was listening on `127.0.0.1:8443` (localhost only) but probes were targeting the pod IP.

## Test plan
- [ ] Verify pod starts successfully after merge
- [ ] Check pod becomes Ready (1/1)
- [ ] Confirm Kubewall UI is accessible via HTTPRoute

🤖 Generated with [Claude Code](https://claude.ai/code)