### PR TITLE
fix(kubewall): implement proper autobrr-style route configuration and health monitoring

### DIFF
--- a/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
@@ -83,5 +83,5 @@ spec:
     service:
       app:
         ports:
-          http:
+          https:
             port: *port

--- a/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
@@ -72,7 +72,7 @@ spec:
           kubewall:
             app:
               - path: /.kubewall
-    route:
+route:
       app:
         hostnames:
           - "{{ .Release.Name }}.hypyr.space"
@@ -80,8 +80,17 @@ spec:
           - name: internal
             namespace: kube-system
             sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
     service:
       app:
         ports:
           https:
             port: *port
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: https
+            path: /

--- a/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kubewall/app/helmrelease.yaml
@@ -72,7 +72,7 @@ spec:
           kubewall:
             app:
               - path: /.kubewall
-route:
+    route:
       app:
         hostnames:
           - "{{ .Release.Name }}.hypyr.space"


### PR DESCRIPTION
## Summary
Fixes kubewall DNS registration and implements proper health monitoring by adopting autobrr's proven route configuration pattern.

## Changes Made
1. **Route Structure**: Copied autobrr's working route configuration with `identifier: app` backendRefs
2. **HTTPS Restoration**: Reverted service port back to `https` (SSE functionality requirement)
3. **Health Monitoring**: Added ServiceMonitor targeting main port at `/` for basic health checks
4. **Configuration Cleanup**: Removed non-existent metrics configuration, fixed indentation

## Root Cause Analysis
- **Original Issue**: external-dns showed "No endpoints could be generated from HTTPRoute observability/kubewall"
- **Previous Fix Attempt**: Changing port name to `http` broke SSE functionality
- **Real Solution**: Route structure needed to match working app-template pattern

## Pattern for Other Apps
This ServiceMonitor pattern (monitoring main port at `/`) should be applied to other apps without built-in metrics:
```yaml
serviceMonitor:
  app:
    endpoints:
      - port: https  # or http
        path: /
```

## Expected Results
- ✅ Kubewall SSE functionality restored (HTTPS preserved)
- ✅ external-dns should generate: `kubewall.hypyr.space → internal.hypyr.space`
- ✅ Basic health monitoring via Prometheus
- ✅ Consistent pattern for other apps to follow

## Test Plan
- [ ] Verify pod remains healthy with HTTPS
- [ ] Confirm DNS record creation by external-dns
- [ ] Check ServiceMonitor appears in Prometheus targets
- [ ] Validate kubewall UI accessible at https://kubewall.hypyr.space

🤖 Generated with [Claude Code](https://claude.ai/code)