### PR TITLE
feat(talos): Add device ownership from security context for improved NFS handling

### DIFF
--- a/talos/static-configs/home01.yaml
+++ b/talos/static-configs/home01.yaml
@@ -40,6 +40,8 @@ machine:
       content: |
         [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true
     - op: overwrite
       path: /etc/nfsmount.conf
       permissions: 0o644

--- a/talos/static-configs/home02.yaml
+++ b/talos/static-configs/home02.yaml
@@ -40,6 +40,8 @@ machine:
       content: |
         [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true
     - op: overwrite
       path: /etc/nfsmount.conf
       permissions: 0o644

--- a/talos/static-configs/home03.yaml
+++ b/talos/static-configs/home03.yaml
@@ -40,6 +40,8 @@ machine:
       content: |
         [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true
     - op: overwrite
       path: /etc/nfsmount.conf
       permissions: 0o644

--- a/talos/static-configs/home04.yaml
+++ b/talos/static-configs/home04.yaml
@@ -40,6 +40,8 @@ machine:
       content: |
         [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true
     - op: overwrite
       path: /etc/nfsmount.conf
       permissions: 0o644

--- a/talos/static-configs/home05.yaml
+++ b/talos/static-configs/home05.yaml
@@ -42,6 +42,8 @@ machine:
       content: |
         [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true
     - op: overwrite
       path: /etc/nfsmount.conf
       permissions: 0o644


### PR DESCRIPTION
## Summary

This PR implements NFS device ownership improvements based on successful optimizations from buroa's k8s-gitops repository. The changes enhance NFS mount handling across the entire cluster by enabling device ownership resolution from security context.

## Changes Made

### Talos Configuration Updates
- **Added ** to containerd CRI runtime configuration across all 5 cluster nodes (home01-home05)
- **Enhances NFS mount device ownership handling** by allowing containerd to properly resolve device ownership from pod security contexts
- **Maintains existing containerd CRI image configuration** while adding the new runtime setting

## Impact Assessment

### Affected Components
- **All 5 Talos cluster nodes** (home01, home02, home03, home04, home05)
- **NFS-mounted applications in media namespace**:
  - Plex, Radarr, Sonarr, Bazarr, QBittorrent, Sabnzbd, Cross-seed, TQM

### Expected Improvements
- **Better device ownership resolution** for NFS-mounted volumes
- **Improved file permission handling** for media applications
- **Enhanced container security context compliance** with NFS mounts
- **Reduced permission-related issues** with NFS storage

### Compatibility
- **No breaking changes** - additive configuration only
- **Maintains existing security contexts** and supplementalGroups configurations
- **Compatible with current NFS mount configurations** 
- **Preserves all existing Talos node features** and settings

## Testing Recommendations

1. **Deploy to cluster** using standard Talos node update procedures
2. **Verify NFS mount behavior** with existing media applications
3. **Check device ownership resolution** for containers using NFS mounts
4. **Monitor for any permission-related issues** post-deployment

## Deployment Notes

- **Requires Talos node restart** to apply containerd configuration changes
- **No impact on running workloads** during rolling restart

🚀 Ready for review and deployment to improve NFS handling across the cluster.